### PR TITLE
make express handlers asynchronous

### DIFF
--- a/backend/src/routers/adminRouter.ts
+++ b/backend/src/routers/adminRouter.ts
@@ -3,6 +3,7 @@ import { getUserUUID, isAdminSession } from "../services/auth";
 import { database } from "../services/database";
 import webpush from "web-push";
 import { testNotificationPayload } from "../services/pushManager";
+import { handleAsync } from "../util/handleAsync";
 
 // endpoints for triggering special administrative commands
 // these endpoints should return error 403 unless the client provides a session token that matches an admin account
@@ -10,17 +11,17 @@ import { testNotificationPayload } from "../services/pushManager";
 export const adminRouter = express.Router();
 
 // example endpoint that verifies that the current user is an admin, returns error 403 otherwise
-adminRouter.post('/check', (req, res) => {
+adminRouter.post('/check', handleAsync(async (req, res) => {
   if (isAdminSession(req)) {
     console.log(`test action by admin user ${getUserUUID(req)}`);
     res.send();
   } else {
     res.sendStatus(403);
   }
-});
+}));
 
 // triggers a push notification to the given username
-adminRouter.post('/push', (req, res) => {
+adminRouter.post('/push', handleAsync(async (req, res) => {
   if (!isAdminSession(req)) {
     res.sendStatus(403);
     return;
@@ -31,28 +32,25 @@ adminRouter.post('/push', (req, res) => {
     return;
   }
 
-  database.getPushByUsername(username)
-    .then((subscriptions: PushSubscriptionJSON[]) => {
-      for (const sub of subscriptions) {
-        try {
-          const subscription: webpush.PushSubscription = {
-            endpoint: sub.endpoint!,
-            keys: {
-              p256dh: sub.keys!['p256dh'],
-              auth: sub.keys!['auth']
-            }
-          };
-          webpush.sendNotification(subscription, JSON.stringify(testNotificationPayload))
-            .catch((reason: unknown) => {
-              console.log("failed to send push notification");
-              console.log(reason);
-            });
-        } catch (reason: unknown) {
+  const subscriptions: PushSubscriptionJSON[] = await database.getPushByUsername(username);
+  for (const sub of subscriptions) {
+    try {
+      const subscription: webpush.PushSubscription = {
+        endpoint: sub.endpoint!,
+        keys: {
+          p256dh: sub.keys!['p256dh'],
+          auth: sub.keys!['auth']
+        }
+      };
+      webpush.sendNotification(subscription, JSON.stringify(testNotificationPayload))
+        .catch((reason: unknown) => {
           console.log("failed to send push notification");
           console.log(reason);
-        }
-      }
-    })
-    .catch(() => res.sendStatus(500));
-});
+        });
+    } catch (reason: unknown) {
+      console.log("failed to send push notification");
+      console.log(reason);
+    }
+  }
+}));
 

--- a/backend/src/routers/databaseExampleRouter.ts
+++ b/backend/src/routers/databaseExampleRouter.ts
@@ -1,27 +1,19 @@
 import express from "express";
 import { database } from "../services/database";
+import { handleAsync } from "../util/handleAsync";
 
 export const databaseExampleRouter = express.Router();
 
-databaseExampleRouter.get('/', (req, res) => {
-  database.getExampleValues()
-    .then((result) => {
-      res.send(result);
-    }).catch((err) => {
-      console.error(err);
-      res.status(500).send('Database error');
-    });
-});
+databaseExampleRouter.get('/', handleAsync(async (req, res) => {
+  const result = await database.getExampleValues();
+  res.send(result);
+}));
 
-databaseExampleRouter.post('/', (req, res) => {
+databaseExampleRouter.post('/', handleAsync(async (req, res) => {
   const body: string = req.body;
   console.log(body);
   console.log(`add value: ${body}`);
   // database queries are asynchronous and we can't send the response until the promise is completed.
-  database.addExampleValue(body)
-    .then(() => { res.send(); })
-    .catch((err) => {
-      console.error(err);
-      res.status(500).send('Database error');
-    });
-});
+  await database.addExampleValue(body);
+  res.send();
+}));

--- a/backend/src/routers/exampleRouter.ts
+++ b/backend/src/routers/exampleRouter.ts
@@ -1,8 +1,9 @@
 import express from "express";
+import { handleAsync } from "../util/handleAsync";
 
 export const exampleRouter = express.Router();
 
-exampleRouter.get('/:id', function(req, res) {
+exampleRouter.get('/:id', handleAsync(async (req, res) => {
   console.log("received GET");
   console.log(req.body);
   console.log(req.headers);
@@ -10,8 +11,8 @@ exampleRouter.get('/:id', function(req, res) {
     message: "GET request received.",
     idPath: req.params.id
   });
-});
-exampleRouter.post('/', function(req, res) {
+}));
+exampleRouter.post('/', handleAsync( async (req, res) => {
   console.log("received POST");
   console.log(req.body);
   console.log(req.headers);
@@ -19,4 +20,4 @@ exampleRouter.post('/', function(req, res) {
     message: "POST request received.",
     payload: req.body
   });
-});
+}));

--- a/backend/src/routers/pushSubscriptionRouter.ts
+++ b/backend/src/routers/pushSubscriptionRouter.ts
@@ -3,37 +3,34 @@ import { testNotificationPayload } from "../services/pushManager";
 import webpush from "web-push";
 import { getUserUUID } from "../services/auth";
 import { database } from "../services/database";
+import { handleAsync } from "../util/handleAsync";
 
 
 
 export const subscriptionRouter = express.Router();
 
-subscriptionRouter.post('/addSubscription', function(req, res) {
+subscriptionRouter.post('/addSubscription', handleAsync(async (req, res) => {
   const subscription: PushSubscriptionJSON = req.body;
   const userUUID = getUserUUID(req);
   if (userUUID === undefined) {
     res.status(401).send("cannot add subscription when not logged in");
     return;
   }
-  database.addPushSubscription(subscription, userUUID)
-    .then(() => { res.send(); })
-    .catch((reason) => {
-      console.error(reason);
-      res.sendStatus(500);
-    });
-});
+  await database.addPushSubscription(subscription, userUUID);
+  res.send();
+}));
 
 // TODO remove notification example
 let mostRecentSub: webpush.PushSubscription | undefined = undefined;
 
-subscriptionRouter.post('/subscribe', function(req, res) {
+subscriptionRouter.post('/subscribe', handleAsync( async (req, res) => {
   console.log("received push subscription information POST");
   console.log(req.body);
   mostRecentSub = req.body;
   res.send();
-});
+}));
 
-subscriptionRouter.post('/testBroadcast', function(req, res) {
+subscriptionRouter.post('/testBroadcast', handleAsync( async (req, res) => {
   console.log("received broadcast instruction");
   if (mostRecentSub === undefined) {
     console.error("no subscriber");
@@ -41,14 +38,14 @@ subscriptionRouter.post('/testBroadcast', function(req, res) {
     return;
   }
   console.log(mostRecentSub);
-  webpush.sendNotification(mostRecentSub, JSON.stringify(testNotificationPayload))
-    .then(() => {
-      console.log("notification sent");
-      res.send();
-    })
-    .catch(err => {
-      console.error("Error sending notification, reason:");
-      console.error(err);
-      res.sendStatus(500);
-    });
-});
+  try {
+    await webpush.sendNotification(mostRecentSub, JSON.stringify(testNotificationPayload));
+  } catch (err: unknown) {
+    console.error("Error sending notification, reason:");
+    console.error(err);
+    res.sendStatus(500);
+    return;
+  }
+  console.log("notification sent");
+  res.send();
+}));

--- a/backend/src/util/handleAsync.ts
+++ b/backend/src/util/handleAsync.ts
@@ -1,0 +1,14 @@
+import Express from "express";
+
+// safely wraps async functions to be used as express handlers, responds with 500 if the async function throws an error
+export function handleAsync(
+  handlerFunction: (req: Express.Request, res: Express.Response) => Promise<void>
+): (req: Express.Request, res: Express.Response) => void {
+  return (request, response) => {
+    handlerFunction(request, response).catch((reason: unknown) => {
+      console.error("unhandled error in async handler");
+      console.error(reason);
+      response.sendStatus(500);
+    });
+  };
+}


### PR DESCRIPTION
All expressJS endpoint handlers are now asynchronous, using a wrapper function that will automatically respond with `500` is there is an unhandled exception. Making our express handlers async makes it easier to use asynchronous operations  such as  database access. This will be particularly useful when we start persisting user sessions in the database, since that will add an additional async call to most endpoints (see issue #9).