### PR TITLE
Keep users logged when app is closed

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -8,6 +8,7 @@ import { databaseExampleRouter } from "./routers/databaseExampleRouter";
 import { accountsRouter } from "./routers/accountsRouter";
 import { promisify } from "util";
 import { adminRouter } from "./routers/adminRouter";
+import { startRepeatedJobs } from "./services/periodicJobs";
 
 const app = express();
 const port = 3000;
@@ -30,6 +31,9 @@ app.use("/admin", adminRouter);
 const server = app.listen(port, () => {
   console.log(`Listening on port ${port}`);
 });
+
+// schedule repeated tasks
+startRepeatedJobs();
 
 // handler to shut down cleanly and free resources
 async function cleanShutdown(): Promise<void> {

--- a/backend/src/routers/accountsRouter.ts
+++ b/backend/src/routers/accountsRouter.ts
@@ -1,5 +1,6 @@
 import express from "express";
-import { failsPasswordRequirement, failsUsernameRequirement, LoginRequest, LoginResponse } from "boop-core";
+import { failsPasswordRequirement, failsUsernameRequirement, LoginRequest, LoginResponse,
+  sessionTokenHeaderName } from "boop-core";
 import { login, LoginError, userUuidFromReq } from "../services/auth";
 import { createAccount } from "../services/userAccounts";
 import { CreateAccountRequest, minYearsAgo, isGender } from "boop-core";
@@ -22,6 +23,14 @@ accountsRouter.post('/login', handleAsync(async (req, res) => {
     res.send(loginResponse);
     return;
   }
+}));
+
+accountsRouter.post('/logout', handleAsync(async (req, res) => {
+  const token: string | undefined = req.header(sessionTokenHeaderName);
+  if (token !== undefined) {
+    await database.removeSession(token);
+  }
+  res.send();
 }));
 
 accountsRouter.post('/register', handleAsync(async (req, res) => {

--- a/backend/src/routers/accountsRouter.ts
+++ b/backend/src/routers/accountsRouter.ts
@@ -1,9 +1,9 @@
 import express from "express";
 import { failsPasswordRequirement, failsUsernameRequirement, LoginRequest, LoginResponse } from "boop-core";
-import { login, userUuidFromReq } from "../services/auth";
+import { login, LoginError, userUuidFromReq } from "../services/auth";
 import { createAccount } from "../services/userAccounts";
 import { CreateAccountRequest, minYearsAgo, isGender } from "boop-core";
-import { database } from "../services/database";
+import { database, DatabaseError } from "../services/database";
 import { handleAsync } from "../util/handleAsync";
 export const accountsRouter = express.Router();
 
@@ -11,11 +11,11 @@ export const accountsRouter = express.Router();
 accountsRouter.post('/login', handleAsync(async (req, res) => {
   const body: LoginRequest = req.body;
   const result = await login(body);
-  if (result === "User Not Found") {
-    res.status(404).send("User Not Found");
+  if (result === LoginError.UserNotFound) {
+    res.sendStatus(404);
     return;
-  } else if (result === "Wrong Password") {
-    res.status(401).send("Incorrect Password");
+  } else if (result === LoginError.WrongPassword) {
+    res.sendStatus(401);
     return;
   } else {
     const loginResponse: LoginResponse = result;
@@ -69,7 +69,7 @@ accountsRouter.get('/exists', handleAsync(async (req, res) => {
     return;
   }
   const result = await database.getAuthInfo(username);
-  if (result === "Account Not Found") {
+  if (result === DatabaseError.UserNotFound) {
     res.send(false);
     return;
   } else {

--- a/backend/src/routers/accountsRouter.ts
+++ b/backend/src/routers/accountsRouter.ts
@@ -1,6 +1,6 @@
 import express from "express";
 import { failsPasswordRequirement, failsUsernameRequirement, LoginRequest, LoginResponse } from "boop-core";
-import { login } from "../services/auth";
+import { login, userUuidFromReq } from "../services/auth";
 import { createAccount } from "../services/userAccounts";
 import { CreateAccountRequest, minYearsAgo, isGender } from "boop-core";
 import { database } from "../services/database";
@@ -76,4 +76,10 @@ accountsRouter.get('/exists', handleAsync(async (req, res) => {
     res.send(true);
     return;
   }
+}));
+
+// tells whether the session header corresponds to a valid session
+accountsRouter.get('/sessionValid', handleAsync(async (req, res) => {
+  const session = await userUuidFromReq(req);
+  res.send((session !== undefined));
 }));

--- a/backend/src/routers/adminRouter.ts
+++ b/backend/src/routers/adminRouter.ts
@@ -12,8 +12,8 @@ export const adminRouter = express.Router();
 
 // example endpoint that verifies that the current user is an admin, returns error 403 otherwise
 adminRouter.post('/check', handleAsync(async (req, res) => {
-  if (isAdminSession(req)) {
-    console.log(`test action by admin user ${getUserUUID(req)}`);
+  if (await isAdminSession(req)) {
+    console.log(`test action by admin user ${await getUserUUID(req)}`);
     res.send();
   } else {
     res.sendStatus(403);
@@ -22,7 +22,7 @@ adminRouter.post('/check', handleAsync(async (req, res) => {
 
 // triggers a push notification to the given username
 adminRouter.post('/push', handleAsync(async (req, res) => {
-  if (!isAdminSession(req)) {
+  if (! (await isAdminSession(req))) {
     res.sendStatus(403);
     return;
   }

--- a/backend/src/routers/adminRouter.ts
+++ b/backend/src/routers/adminRouter.ts
@@ -1,5 +1,5 @@
 import express from "express";
-import { getUserUUID, isAdminSession } from "../services/auth";
+import { userUuidFromReq, isAdminSessionFromReq } from "../services/auth";
 import { database } from "../services/database";
 import webpush from "web-push";
 import { testNotificationPayload } from "../services/pushManager";
@@ -12,8 +12,8 @@ export const adminRouter = express.Router();
 
 // example endpoint that verifies that the current user is an admin, returns error 403 otherwise
 adminRouter.post('/check', handleAsync(async (req, res) => {
-  if (await isAdminSession(req)) {
-    console.log(`test action by admin user ${await getUserUUID(req)}`);
+  if (await isAdminSessionFromReq(req)) {
+    console.log(`test action by admin user ${await userUuidFromReq(req)}`);
     res.send();
   } else {
     res.sendStatus(403);
@@ -22,7 +22,7 @@ adminRouter.post('/check', handleAsync(async (req, res) => {
 
 // triggers a push notification to the given username
 adminRouter.post('/push', handleAsync(async (req, res) => {
-  if (! (await isAdminSession(req))) {
+  if (! (await isAdminSessionFromReq(req))) {
     res.sendStatus(403);
     return;
   }

--- a/backend/src/routers/pushSubscriptionRouter.ts
+++ b/backend/src/routers/pushSubscriptionRouter.ts
@@ -1,7 +1,7 @@
 import express from "express";
 import { testNotificationPayload } from "../services/pushManager";
 import webpush from "web-push";
-import { getUserUUID } from "../services/auth";
+import { userUuidFromReq } from "../services/auth";
 import { database } from "../services/database";
 import { handleAsync } from "../util/handleAsync";
 
@@ -11,7 +11,7 @@ export const subscriptionRouter = express.Router();
 
 subscriptionRouter.post('/addSubscription', handleAsync(async (req, res) => {
   const subscription: PushSubscriptionJSON = req.body;
-  const userUUID = await getUserUUID(req);
+  const userUUID = await userUuidFromReq(req);
   if (userUUID === undefined) {
     res.status(401).send("cannot add subscription when not logged in");
     return;

--- a/backend/src/routers/pushSubscriptionRouter.ts
+++ b/backend/src/routers/pushSubscriptionRouter.ts
@@ -11,7 +11,7 @@ export const subscriptionRouter = express.Router();
 
 subscriptionRouter.post('/addSubscription', handleAsync(async (req, res) => {
   const subscription: PushSubscriptionJSON = req.body;
-  const userUUID = getUserUUID(req);
+  const userUUID = await getUserUUID(req);
   if (userUUID === undefined) {
     res.status(401).send("cannot add subscription when not logged in");
     return;

--- a/backend/src/services/auth.ts
+++ b/backend/src/services/auth.ts
@@ -35,12 +35,12 @@ async function sessionFromReq(req: Request): Promise<Session | undefined> {
 }
 
 // gets the user UUID associated with a session token, or undefined if the token does not match any active session
-export async function getUserUUID(req: Request): Promise<string | undefined> {
+export async function userUuidFromReq(req: Request): Promise<string | undefined> {
   return (await sessionFromReq(req))?.userUUID;
 }
 
 // returns true if the session token belongs to an "admin" user
-export async function isAdminSession(req: Request): Promise<boolean> {
+export async function isAdminSessionFromReq(req: Request): Promise<boolean> {
   return (await sessionFromReq(req))?.isAdmin ?? false;
 }
 

--- a/backend/src/services/auth.ts
+++ b/backend/src/services/auth.ts
@@ -4,21 +4,10 @@ import { database } from './database';
 import bcrypt from "bcrypt";
 import { Request } from "express";
 
-/* a user session token is a UUID that is given to the client when it logs in
- * the token is sent as a header in all requests made to the back-end in order to verify the client's identity
- */
-type Session = {
-  userUUID: string; // the permanent UUID for this user account, not the same as the username
-  isAdmin: boolean;
-};
+export type Session = {userUUID: string; isAdmin: boolean;};
 
-// map from auth tokens to sessions
-const activeSessions: Map<string, Session> = new Map();
-
-// a prefix is included in session tokens to distinguish them from permanent user UUIDs
-function generateSessionToken(): string {
-  return `session-${uuidv4()}`;
-}
+// 30 days expressed in milliseconds; user sessions will be closed if left inactive for this time
+export const sessionTimeoutDuration: number = 30 * 24 * 60 * 60 * 1000;
 
 // validate password and create log-in session
 export async function login(credentials: LoginRequest): Promise<LoginResponse | "User Not Found" | "Wrong Password"> {
@@ -28,38 +17,32 @@ export async function login(credentials: LoginRequest): Promise<LoginResponse | 
   }
   // validating password with a bcrypt hash is an asynchronous operation because it is *very* slow
   if (await bcrypt.compare(credentials.password, userInfo.hash)) {
-    const session: Session = {
-      userUUID: userInfo.userUUID,
-      isAdmin: userInfo.isAdmin,
-    };
-    const token: string = generateSessionToken();
-    activeSessions.set(token, session);
-    return { userUUID: session.userUUID, sessionToken: token };
+    // a prefix is included in session tokens to prevent confusing them with user UUIDs
+    const token: string = `session-${uuidv4()}`;
+    await database.setSession(token, userInfo.userUUID);
+    return { userUUID: userInfo.userUUID, sessionToken: token };
   } else {
     return "Wrong Password";
   }
 }
 
-function sessionFromReq(req: Request): Session | undefined {
+async function sessionFromReq(req: Request): Promise<Session | undefined> {
   const token: string | undefined = req.header(sessionTokenHeaderName);
-  if (typeof token === "string") {
-    return activeSessions.get(token);
-  } else {
+  if (typeof token !== "string") {
     return undefined;
   }
-
+  return await database.getSession(token);
 }
 
 // gets the user UUID associated with a session token, or undefined if the token does not match any active session
-export function getUserUUID(req: Request): string | undefined {
-  return sessionFromReq(req)?.userUUID;
+export async function getUserUUID(req: Request): Promise<string | undefined> {
+  return (await sessionFromReq(req))?.userUUID;
 }
 
 // returns true if the session token belongs to an "admin" user
-export function isAdminSession(req: Request): boolean {
-  return sessionFromReq(req)?.isAdmin ?? false;
+export async function isAdminSession(req: Request): Promise<boolean> {
+  return (await sessionFromReq(req))?.isAdmin ?? false;
 }
-
 
 export async function hashPassword(password: string): Promise<string> {
   // incrementing salt rounds number by 1 doubles the time needed to calculate a hash

--- a/backend/src/services/database.ts
+++ b/backend/src/services/database.ts
@@ -106,6 +106,10 @@ class Database {
     await this.pool.query(query, [oldestAllowedTime]);
   }
 
+  async removeSession(token: string): Promise<void> {
+    await this.pool.query(`delete from sessions where token = $1;`, [token]);
+  }
+
   async addAccount(values: {
     uuid: string;
     username: string;

--- a/backend/src/services/database.ts
+++ b/backend/src/services/database.ts
@@ -3,6 +3,11 @@ import parseArgs from "minimist";
 import { Gender } from "boop-core";
 import { Session, sessionTimeoutDuration } from "./auth";
 
+// value-level signals indicating when certain database queries could not succeed
+export enum DatabaseError {
+  UserNotFound
+}
+
 // manages our connection to PostgreSQL database
 class Database {
 
@@ -57,12 +62,12 @@ class Database {
 
   // information needed authenticate and log in a user
   async getAuthInfo(username: string):
-  Promise<{userUUID: string; hash: string; isAdmin: boolean;} | "Account Not Found"> {
+  Promise<{userUUID: string; hash: string; isAdmin: boolean;} | DatabaseError.UserNotFound> {
     const query = 'SELECT "user_uuid", "bcrypt_hash", "is_admin" from users where username = $1;';
     type resultRow = { user_uuid: string; bcrypt_hash: string; is_admin: boolean; };
     const rows: resultRow[] = (await this.pool.query(query, [username])).rows;
     if (rows.length === 0) {
-      return "Account Not Found";
+      return DatabaseError.UserNotFound;
     } else if (rows.length === 1) {
       const result = rows[0];
       // TODO add support admin column

--- a/backend/src/services/periodicJobs.ts
+++ b/backend/src/services/periodicJobs.ts
@@ -1,0 +1,16 @@
+import { database } from "./database";
+
+// tasks that should be repeated at a regular interval
+
+function clearExpiredSessions(): void {
+  database.removeExpiredSessions()
+    .catch(err => {
+      console.error("failed to clear expired authentication sessions");
+      console.error(err);
+    });
+}
+
+export function startRepeatedJobs(): void {
+  // check for expired user sessions every 30 minutes
+  setInterval(clearExpiredSessions, (30 * 60 * 1000));
+}

--- a/backend/src/services/userAccounts.ts
+++ b/backend/src/services/userAccounts.ts
@@ -2,7 +2,7 @@ import { CreateAccountRequest, genderValues } from "boop-core";
 import { LoginResponse } from "boop-core";
 import { database } from "./database";
 import { v4 as uuidv4 } from 'uuid';
-import { hashPassword, login } from "./auth";
+import { hashPassword, login, LoginError } from "./auth";
 
 export async function createAccount(request: CreateAccountRequest): Promise<LoginResponse> {
   const accountUUID = uuidv4();
@@ -25,7 +25,7 @@ export async function createAccount(request: CreateAccountRequest): Promise<Logi
     passwordHash: passwordHash,
   });
   const loginResult = await login({ username: request.username, password: request.password });
-  if (loginResult === "Wrong Password" || loginResult === "User Not Found") {
+  if (loginResult === LoginError.WrongPassword || loginResult === LoginError.UserNotFound) {
     // this should never happen because we just created an account using those credentials
     throw Error("failed to authenticate after creating account");
   } else {

--- a/core/src/datatypes/authentication.ts
+++ b/core/src/datatypes/authentication.ts
@@ -7,3 +7,15 @@ export type LoginResponse = {
   userUUID: string;
   sessionToken: string; // used to verify identity when making requests to backend
 };
+
+export function isLoginResponse(x: unknown): x is LoginResponse {
+  if (typeof x !== "object" || x === null) {
+    return false;
+  }
+  for (const field of ["userUUID", "sessionToken"]) {
+    if (typeof (x as any)[field] !== "string") {
+      return false;
+    }
+  }
+  return true;
+}

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -7,7 +7,7 @@ import { NotFound404Component } from './components/not-found404/not-found404.com
 import { PushSubscribeComponent } from './components/push-subscribe/push-subscribe.component';
 /* eslint-disable @typescript-eslint/no-extraneous-class */
 const routes: Routes = [
-  { path: '', redirectTo: '/welcome', pathMatch: 'full' },
+  { path: '', redirectTo: '/home', pathMatch: 'full' },
   { path: 'welcome', component: LandingComponent },
   { path: 'home', component: HomeComponent },
   { path: 'push_setup', component: PushSubscribeComponent },

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,14 +1,46 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Router } from '@angular/router';
+import { SessionService } from './services/session.service';
 
 // a minimal component that acts as the root of the page
 @Component({
   selector: 'app-root',
   template: `
   <h1 class="boop-header mat-display-1">Boop</h1>
-  <router-outlet></router-outlet>
+  <div class="narrow-body" style="margin-top: 50px;">
+    <mat-progress-bar *ngIf="initialLoading" mode="indeterminate"></mat-progress-bar>
+  </div>
+  <router-outlet *ngIf="!initialLoading"></router-outlet>
   `,
   styles: []
 })
-export class AppComponent {
-  title = 'boop-web';
+export class AppComponent implements OnInit {
+
+  initialLoading: boolean = true;
+
+  constructor(
+    private sessionService: SessionService,
+    private router: Router,
+    private snackBar: MatSnackBar,
+  ) { }
+
+  ngOnInit(): void {
+    this.sessionService.loadSavedSession().then(
+      (savedLoaded) => {
+        console.log("loaded saved session", savedLoaded);
+        if (!savedLoaded) {
+          void this.router.navigate(["/welcome"]).finally(() => { this.initialLoading = false; });
+        } else {
+          this.initialLoading = false;
+        }
+      }
+    )
+      .catch((err: unknown) => {
+        console.error(err);
+        this.initialLoading = false;
+        this.snackBar.open("Error: Could not connect to server.", "Dismiss");
+      });
+  }
+
 }

--- a/frontend/src/app/components/home/home.component.html
+++ b/frontend/src/app/components/home/home.component.html
@@ -3,5 +3,6 @@
 <p *ngIf="!getUserID()">Not logged it</p>
 <button routerLink="/test">Go to api examples page</button>
 <button routerLink="/push_setup">Go to push setup</button>
+<button (click)="logout()">Log Out</button>
 
 

--- a/frontend/src/app/components/home/home.component.ts
+++ b/frontend/src/app/components/home/home.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
 import { SessionService } from 'src/app/services/session.service';
 
@@ -13,6 +14,7 @@ export class HomeComponent implements OnInit {
   constructor(
     private sessionService: SessionService,
     private router: Router,
+    private snackBar: MatSnackBar,
   ) { }
 
   getUserID(): string | undefined {
@@ -25,6 +27,15 @@ export class HomeComponent implements OnInit {
     if (this.sessionService.getSessionToken() === undefined) {
       void this.router.navigate(["/"]);
     }
+  }
+
+  logout(): void {
+    this.sessionService.logout().then(
+      () => { void this.router.navigate(["/"]); }
+    ).catch((reason) => {
+      console.error(reason);
+      this.snackBar.open("Something went wrong when trying to log out.", "Dismiss", { "duration": 5000 });
+    });
   }
 
 }

--- a/frontend/src/app/components/home/home.component.ts
+++ b/frontend/src/app/components/home/home.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
+import { CommandsService } from 'src/app/services/commands.service';
 import { SessionService } from 'src/app/services/session.service';
 
 @Component({
@@ -15,6 +16,7 @@ export class HomeComponent implements OnInit {
     private sessionService: SessionService,
     private router: Router,
     private snackBar: MatSnackBar,
+    private commandService: CommandsService
   ) { }
 
   getUserID(): string | undefined {
@@ -27,6 +29,8 @@ export class HomeComponent implements OnInit {
     if (this.sessionService.getSessionToken() === undefined) {
       void this.router.navigate(["/"]);
     }
+    // attach admin debug commands to browser console
+    this.commandService.enableAdminCommands();
   }
 
   logout(): void {

--- a/frontend/src/app/components/home/home.component.ts
+++ b/frontend/src/app/components/home/home.component.ts
@@ -27,7 +27,7 @@ export class HomeComponent implements OnInit {
     // return user to the landing page if they are not logged in
     // TODO make sure this still behaves correctly after the session service can remember logins between sessions
     if (this.sessionService.getSessionToken() === undefined) {
-      void this.router.navigate(["/"]);
+      void this.router.navigate(["/welcome"]);
     }
     // attach admin debug commands to browser console
     this.commandService.enableAdminCommands();
@@ -35,7 +35,7 @@ export class HomeComponent implements OnInit {
 
   logout(): void {
     this.sessionService.logout().then(
-      () => { void this.router.navigate(["/"]); }
+      () => { void this.router.navigate(["/welcome"]); }
     ).catch((reason) => {
       console.error(reason);
       this.snackBar.open("Something went wrong when trying to log out.", "Dismiss", { "duration": 5000 });

--- a/frontend/src/app/components/landing/landing.component.html
+++ b/frontend/src/app/components/landing/landing.component.html
@@ -15,13 +15,13 @@
                 <div class="horizontal-center close-stacked-input">
                     <mat-form-field appearance="outline">
                         <mat-label>Password</mat-label>
-                        <input matInput formControlName="password" type="password">
+                        <input matInput formControlName="password" type="password" (keyup)="checkConfirmPassword()">
                     </mat-form-field>
                 </div>
                 <div class="horizontal-center close-stacked-input">
                     <mat-form-field appearance="outline">
                         <mat-label>Confirm Password</mat-label>
-                        <input matInput formControlName="confirmPassword" type="password">
+                        <input matInput formControlName="confirmPassword" type="password" (keyup)="checkConfirmPassword()">
                     </mat-form-field>
                 </div>
                 <div style="text-align: center;">

--- a/frontend/src/app/components/landing/landing.component.ts
+++ b/frontend/src/app/components/landing/landing.component.ts
@@ -5,7 +5,6 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
 import { failsPasswordRequirement, failsUsernameRequirement, LoginRequest } from 'boop-core';
 import { ApiService } from 'src/app/services/api.service';
-import { CommandsService } from 'src/app/services/commands.service';
 import { SessionService } from 'src/app/services/session.service';
 import { equalToSiblingValidator } from 'src/app/util/ngUtils';
 
@@ -24,7 +23,6 @@ export class LandingComponent implements OnInit {
     private snackBar: MatSnackBar,
     private router: Router,
     private apiService: ApiService,
-    private commandService: CommandsService,
   ) {
     this.startRegistrationForm.controls.password.valueChanges.subscribe(() => {
       this.startRegistrationForm.controls.confirmPassword.updateValueAndValidity();
@@ -80,7 +78,6 @@ export class LandingComponent implements OnInit {
       const password: string = value.password;
       this.sessionService.login({ username, password }).then(() => {
         // navigate to home page if login was successful
-        this.commandService.enableAdminCommands();
         void this.router.navigate(["/home"]);
       }).catch((reason: unknown) => {
         // if something went wrong, show a "snackbar" message

--- a/frontend/src/app/components/landing/landing.component.ts
+++ b/frontend/src/app/components/landing/landing.component.ts
@@ -23,13 +23,8 @@ export class LandingComponent implements OnInit {
     private snackBar: MatSnackBar,
     private router: Router,
     private apiService: ApiService,
-  ) {
-    this.startRegistrationForm.controls.password.valueChanges.subscribe(() => {
-      this.startRegistrationForm.controls.confirmPassword.updateValueAndValidity();
-    });
-  }
+  ) { }
 
-  // TODO validate username and password formats
   startRegistrationForm: FormGroup = new FormGroup({
     username: new FormControl('', [Validators.required]),
     password: new FormControl('', [Validators.required]),
@@ -40,6 +35,14 @@ export class LandingComponent implements OnInit {
     username: new FormControl('', [Validators.required]),
     password: new FormControl('', [Validators.required]),
   });
+
+  // re-checks whether confirm password matches password and updates control's appearance
+  checkConfirmPassword(): void {
+    const confirmPassword = this.startRegistrationForm.controls.confirmPassword;
+    confirmPassword.updateValueAndValidity();
+    confirmPassword.markAsDirty();
+    confirmPassword.markAsTouched();
+  }
 
   ngOnInit(): void {
   }

--- a/frontend/src/app/materialDependencies.ts
+++ b/frontend/src/app/materialDependencies.ts
@@ -8,6 +8,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatNativeDateModule } from '@angular/material/core';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatDialogModule } from '@angular/material/dialog';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
 
 // include all of the material component modules that we use here to avoid cluttering the main AppModule
 export const materialModules = [
@@ -21,5 +22,6 @@ export const materialModules = [
   MatNativeDateModule,
   MatCheckboxModule,
   MatDialogModule,
+  MatProgressBarModule,
 ];
 

--- a/frontend/src/app/services/session.service.ts
+++ b/frontend/src/app/services/session.service.ts
@@ -60,9 +60,21 @@ export class SessionService {
   }
 
   async logout(): Promise<void> {
-    // TODO send something to the backend to tell it to remove this session
+    const token = this.currentSession?.sessionToken;
     this.currentSession = undefined;
     localStorage.removeItem(sessionLSKey);
+    if (token !== undefined) {
+      // we tell the backend that it should close the session, but we don't need to await for the response
+      this.httpClient.post(
+        "http://localhost:3000/account/logout",
+        undefined,
+        { headers: new HttpHeaders({ [sessionTokenHeaderName]: token }) }
+      ).toPromise()
+        .catch((err) => {
+          console.error("Failed to close session with backend");
+          console.log(err);
+        });
+    }
   }
 
   private saveSession(session: LoginResponse): void {

--- a/frontend/src/app/services/session.service.ts
+++ b/frontend/src/app/services/session.service.ts
@@ -12,9 +12,10 @@ export class SessionService {
   private currentSession: LoginResponse | undefined;
 
   constructor(
-    private httpClient: HttpClient
+    private httpClient: HttpClient,
   ) {
     // load existing session if one is saved
+    // TODO check with backend to make sure that session has not expired
     this.currentSession = this.retrieveSession();
   }
 

--- a/frontend/src/app/services/session.service.ts
+++ b/frontend/src/app/services/session.service.ts
@@ -66,20 +66,24 @@ export class SessionService {
   }
 
   private saveSession(session: LoginResponse): void {
-    localStorage.setItem(sessionLSKey, JSON.stringify(session));
+    try {
+      localStorage.setItem(sessionLSKey, JSON.stringify(session));
+    } catch (err) {
+      console.error(err);
+    }
   }
 
   private retrieveSession(): LoginResponse | undefined {
-    const saved = localStorage.getItem(sessionLSKey);
-    if (saved !== null) {
-      try {
+    try {
+      const saved = localStorage.getItem(sessionLSKey);
+      if (saved !== null) {
         const session: unknown = JSON.parse(saved);
         if (isLoginResponse(session)) {
           return session;
         }
-      } catch {
-        return undefined;
       }
+    } catch (err) {
+      console.error(err);
     }
     return undefined;
   }

--- a/frontend/src/app/services/session.service.ts
+++ b/frontend/src/app/services/session.service.ts
@@ -49,6 +49,11 @@ export class SessionService {
       return true;
     } else {
       this.snackBar.open("Your previous session has timed out.", "Dismiss", { "duration": 5000 });
+      try {
+        localStorage.removeItem(sessionLSKey);
+      } catch (err) {
+        console.error(err);
+      }
       return false;
     }
   }

--- a/frontend/src/app/services/session.service.ts
+++ b/frontend/src/app/services/session.service.ts
@@ -29,6 +29,7 @@ export class SessionService {
     this.currentSession = (await this.httpClient.post<LoginResponse>(
       "http://localhost:3000/account/register", request
     ).toPromise());
+    this.saveSession(this.currentSession);
   }
 
   // attempts to load saved session if it exists, returns false if it doesn't or it has expired.

--- a/frontend/src/app/services/session.service.ts
+++ b/frontend/src/app/services/session.service.ts
@@ -1,6 +1,8 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { CreateAccountRequest, LoginRequest, LoginResponse } from 'boop-core';
+import { CreateAccountRequest, isLoginResponse, LoginRequest, LoginResponse } from 'boop-core';
+
+const sessionLSKey = "boop-session"; // key for storing sessions in local storage
 
 @Injectable({
   providedIn: 'root'
@@ -11,13 +13,17 @@ export class SessionService {
 
   constructor(
     private httpClient: HttpClient
-  ) { }
+  ) {
+    // load existing session if one is saved
+    this.currentSession = this.retrieveSession();
+  }
 
   async login(credentials: LoginRequest): Promise<void> {
     // TODO parameterize backend domain instead of specifying localhost
     this.currentSession = (await this.httpClient.post<LoginResponse>(
       "http://localhost:3000/account/login", credentials
     ).toPromise());
+    this.saveSession(this.currentSession);
   }
 
   async loginNewAccount(request: CreateAccountRequest): Promise<void> {
@@ -33,8 +39,28 @@ export class SessionService {
     return this.currentSession?.userUUID;
   }
 
-  logout(): void {
-    // TODO send something to the backend to tell it to remote this session
+  async logout(): Promise<void> {
+    // TODO send something to the backend to tell it to remove this session
     this.currentSession = undefined;
+    localStorage.removeItem(sessionLSKey);
+  }
+
+  private saveSession(session: LoginResponse): void {
+    localStorage.setItem(sessionLSKey, JSON.stringify(session));
+  }
+
+  private retrieveSession(): LoginResponse | undefined {
+    const saved = localStorage.getItem(sessionLSKey);
+    if (saved !== null) {
+      try {
+        const session: unknown = JSON.parse(saved);
+        if (isLoginResponse(session)) {
+          return session;
+        }
+      } catch {
+        return undefined;
+      }
+    }
+    return undefined;
   }
 }

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>BoopWeb</title>
+  <title>Boop</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">

--- a/frontend/src/manifest.webmanifest
+++ b/frontend/src/manifest.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "boop-web",
-  "short_name": "boop-web",
+  "name": "Boop",
+  "short_name": "Boop",
   "theme_color": "#1976d2",
   "background_color": "#fafafa",
   "display": "standalone",

--- a/init.sql
+++ b/init.sql
@@ -44,4 +44,11 @@ CREATE Table subscriptions(
     user_uuid UUID NOT NULL REFERENCES users (user_uuid) ON DELETE CASCADE,
     endpoint TEXT NOT NULL,
     PRIMARY Key (endpoint, user_uuid)
-)
+);
+
+-- user log-in sessions
+CREATE TABLE sessions(
+    token text PRIMARY KEY,
+    user_uuid UUID NOT NULL REFERENCES users (user_uuid) ON DELETE CASCADE,
+    time_last_touched bigint NOT NULL -- time this session was last accessed, in milliseconds since epoch
+);


### PR DESCRIPTION
This PR addresses issue #9.

The frontend now uses localstorage to remember session tokens when the tab is closed or refreshed. The backend now keeps sessions in a database table instead of in memory, and will remember sessions until they go 30 days without being used. The home page, landing page, and app-component have been slightly modified to support recovering existing sessions and allow links to pages within the app to still work when the user is logged in, rather than always redirecting to the landing page or home page. I also addressed issue #2 in the process.