### PR TITLE
start birthday picker in year selection

### DIFF
--- a/frontend/src/app/components/landing/register/register.component.html
+++ b/frontend/src/app/components/landing/register/register.component.html
@@ -37,9 +37,9 @@
     <div class="horizontal-center close-stacked-input">
         <mat-form-field appearance="outline">
             <mat-label>Birth Date</mat-label>
-            <input readonly matInput [matDatepicker]="picker" formControlName="birthDate" (click)="picker.open()">
+            <input readonly matInput [matDatepicker]="picker" [max]="birthdayMax" [min]="birthdayMin" formControlName="birthDate" (click)="picker.open()">
             <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
-            <mat-datepicker #picker></mat-datepicker>
+            <mat-datepicker #picker startView="multi-year" ></mat-datepicker>
         </mat-form-field>
     </div>
     <div class="horizontal-center">

--- a/frontend/src/app/components/landing/register/register.component.ts
+++ b/frontend/src/app/components/landing/register/register.component.ts
@@ -30,6 +30,10 @@ export class RegisterComponent implements OnInit {
     agreeToTerms: new FormControl(false, [Validators.requiredTrue]),
   });
 
+  readonly birthdayMax = new Date((new Date().getFullYear() - 12), 11, 31);
+  readonly birthdayMin = new Date(1903, 0, 1); // lower bound 1 day older than oldest living person at time of writing
+
+
   constructor(
     private sessionService: SessionService,
     private snackBar: MatSnackBar,


### PR DESCRIPTION
this is a super minor change but it bothered me that the birthday selection datepicker started zoomed into the current date. Newborn babies cannot use our service, so the datepicker now starts out in year-selection.