### PR TITLE
add http PUT and DELETE methods to api service

### DIFF
--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -15,15 +15,6 @@ export class ApiService {
     private sessionService: SessionService,
   ) { }
 
-  private getAuthenticationHeader(): HttpHeaders | undefined {
-    const sessionToken = this.sessionService.getSessionToken();
-    if (sessionToken === undefined) {
-      return undefined;
-    }
-    return new HttpHeaders({ [sessionTokenHeaderName]: sessionToken });
-  }
-
-  // generic method for making http get requests
   async getJSON<ResponseBodyT>(
     endPointUrl: string,
     queryParams?: {[param: string]: string | string[];}
@@ -45,6 +36,32 @@ export class ApiService {
     return this.httpClient.post<ResponseBodyT>(endPointUrl, body, options).toPromise();
   }
 
-  // TODO PUT method
-  // TODO DELETE method
+  async putJSON<RequestBodyT, ResponseBodyT>(
+    endPointUrl: string,
+    body: RequestBodyT
+  ): Promise<ResponseBodyT> {
+    const options = {
+      headers: this.getAuthenticationHeader(),
+    };
+    return this.httpClient.put<ResponseBodyT>(endPointUrl, body, options).toPromise();
+  }
+
+  async deleteJSON<ResponseBodyT>(
+    endPointUrl: string,
+    queryParams?: {[param: string]: string | string[];}
+  ): Promise<ResponseBodyT> {
+    const options = {
+      params: queryParams,
+      headers: this.getAuthenticationHeader(),
+    };
+    return this.httpClient.delete<ResponseBodyT>(endPointUrl, options).toPromise();
+  }
+
+  private getAuthenticationHeader(): HttpHeaders | undefined {
+    const sessionToken = this.sessionService.getSessionToken();
+    if (sessionToken === undefined) {
+      return undefined;
+    }
+    return new HttpHeaders({ [sessionTokenHeaderName]: sessionToken });
+  }
 }


### PR DESCRIPTION
requests made by the frontend to the backend (except for a few endpoints used in the login process) are done through api-service, which automatically adds the authentication token header. We previously were only using POST and GET http methods, but we need to add methods for PUT and DELETE to support RESTful API in upcoming features such as account settings.