### PR TITLE
"Do Not Disturb" and "Custom Status Messages"

### DIFF
--- a/backend/src/queries/accountQueries.ts
+++ b/backend/src/queries/accountQueries.ts
@@ -10,10 +10,10 @@ export async function createAccount(request: CreateAccountRequest): Promise<Logi
 
   const query =
       `INSERT INTO users
-      ("user_uuid", "username", "bcrypt_hash", "full_name", "friendly_name", "gender", "email", "birth_date",
-      "is_admin") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9);`;
+      ("user_uuid", "username", "bcrypt_hash", "full_name", "friendly_name", "gender", "email", "birth_date")
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8);`;
   const params = [accountUUID, request.username, passwordHash, request.fullName, request.friendlyName,
-    request.gender, request.emailAddress, request.birthDate, false];
+    request.gender, request.emailAddress, request.birthDate];
 
   try {
     await database.query(query, params);

--- a/backend/src/queries/friendsQueries.ts
+++ b/backend/src/queries/friendsQueries.ts
@@ -8,17 +8,22 @@ export const deleteFriendRequestQueryString: string =
 
 export async function getIncomingFriendRequests(uuid: string): Promise<ProfileSummary[]> {
   const query =
-    `select distinct user_uuid, username, full_name from users join friend_requests
+    `select distinct user_uuid, username, full_name, status_message from users join friend_requests
     on user_uuid = from_user where to_user = $1;`;
-  type ResultRow = {user_uuid: string; username: string; full_name: string;};
+  type ResultRow = {user_uuid: string; username: string; full_name: string; status_message: string | null;};
   const results: ResultRow[] = await database.query(query, [uuid]);
-  return results.map(r => ({ uuid: r.user_uuid, username: r.username, fullName: r.full_name }));
+  return results.map(r =>
+    ({ uuid: r.user_uuid, username: r.username, fullName: r.full_name, statusMessage: r.status_message ?? "" })
+  );
 }
 
 export async function getFriends(uuid: string): Promise<ProfileSummary[]> {
   const query =
-    `select distinct user_uuid, username, full_name from friends join users on user_a = user_uuid where user_b = $1;`;
-  type ResultRow = {user_uuid: string; username: string; full_name: string;};
+    `select distinct user_uuid, username, full_name, status_message
+    from friends join users on user_a = user_uuid where user_b = $1;`;
+  type ResultRow = {user_uuid: string; username: string; full_name: string; status_message: string | null;};
   const results: ResultRow[] = await database.query(query, [uuid]);
-  return results.map(r => ({ uuid: r.user_uuid, username: r.username, fullName: r.full_name }));
+  return results.map(r =>
+    ({ uuid: r.user_uuid, username: r.username, fullName: r.full_name, statusMessage: r.status_message ?? "" })
+  );
 }

--- a/backend/src/routers/userInfoRouter.ts
+++ b/backend/src/routers/userInfoRouter.ts
@@ -8,14 +8,33 @@ export const userInfoRouter = express.Router();
 userInfoRouter.get('/home_info', handleAsync(async (req, res) => {
   const userUUID = await authenticateUUID(req);
 
-  const query = `select friendly_name from users where user_uuid = $1`;
-  type ResultRow = {friendly_name: string;};
+  const query = `select friendly_name, status_message, do_not_disturb from users where user_uuid = $1`;
+  type ResultRow = {friendly_name: string; status_message: string | null; do_not_disturb: boolean | null;};
   const results: ResultRow[] = (await database.query(query, [userUUID]));
   if (results.length === 0) {
     // user should always be found since we already checked that the session token matches a user uuid
     throwBoopError("Something went wrong when retrieving your information.", 500);
   }
   const result = results[0];
-  const response: HomeScreenInfoResponse = { friendlyName: result.friendly_name };
+  const response: HomeScreenInfoResponse = {
+    friendlyName: result.friendly_name,
+    statusMessage: result.status_message ?? "",
+    doNotDisturb: result.do_not_disturb ?? false
+  };
   res.send(response);
+}));
+
+userInfoRouter.put('/update_status', handleAsync(async (req, res) => {
+  const userUUID: string = await authenticateUUID(req);
+  const message: string = req.body;
+  await database.query(`UPDATE users SET status_message=$1 WHERE user_uuid=$2;`, [message, userUUID]);
+  res.send();
+}));
+
+
+userInfoRouter.put('/update_do_not_disturb', handleAsync(async (req, res) => {
+  const userUUID: string = await authenticateUUID(req);
+  const do_not_disturb: boolean = req.body;
+  await database.query(`UPDATE users SET do_not_disturb=$1 WHERE user_uuid=$2;`, [do_not_disturb, userUUID]);
+  res.send();
 }));

--- a/core/src/datatypes/info.ts
+++ b/core/src/datatypes/info.ts
@@ -1,4 +1,6 @@
 // the information that is displayed on the home screen
 export type HomeScreenInfoResponse = {
   friendlyName: string;
+  statusMessage: string;
+  doNotDisturb: boolean;
 };

--- a/core/src/datatypes/profile.ts
+++ b/core/src/datatypes/profile.ts
@@ -4,6 +4,7 @@ export type ProfileSummary = {
   uuid: string;
   username: string;
   fullName: string;
+  statusMessage: string;
   // TODO include profile image
 };
 

--- a/frontend/src/app/components/friends/friends.component.html
+++ b/frontend/src/app/components/friends/friends.component.html
@@ -22,6 +22,9 @@
         <mat-card-title>{{friend.fullName}}</mat-card-title>
         <mat-card-subtitle style="margin-bottom: 0;">{{friend.username}}</mat-card-subtitle>
       </mat-card-header>
+      <div style="margin-left: 15px;">
+        <p style="margin-bottom: 0; margin-top: -10px;" *ngIf="friend.statusMessage"> <mat-icon style="position: relative; top: 7px;">sticky_note_2</mat-icon>“{{friend.statusMessage}}”</p>
+      </div>
       <mat-card-actions style="padding-top: 0;">
         <button mat-button (click)="unfriend(friend.uuid)" color="warn">UNFRIEND</button>
       </mat-card-actions>

--- a/frontend/src/app/components/home/home.component.html
+++ b/frontend/src/app/components/home/home.component.html
@@ -1,11 +1,42 @@
 <app-loading-bar *ngIf="info === undefined"></app-loading-bar>
 <ng-container *ngIf="info">
     <h2 style="text-align: center; font-size: x-large;">{{getGreeting(info!.friendlyName)}}</h2>
-    <div style="text-align: center; width: 4in; margin: auto;">
-      <button mat-stroked-button routerLink="/add_friends"><mat-icon>group</mat-icon> Friends</button>
-      <button mat-stroked-button routerLink="/push_setup"><mat-icon>notification_add</mat-icon> Notification Setup</button>
-      <button mat-stroked-button routerLink="/edit_contact_info"><mat-icon>alternate_email</mat-icon> Edit Contact Info</button>
-      <button mat-stroked-button routerLink="/settings"><mat-icon>manage_accounts</mat-icon> Account Settings</button>
-      <button mat-stroked-button color="warn" (click)="logout()"><mat-icon>logout</mat-icon> Log Out</button>
+    <div style="width: 4in; margin: auto;">
+      <div style="width: 80%; margin: auto;">
+        <button mat-stroked-button routerLink="/add_friends"><mat-icon>group</mat-icon> Friends</button>
+        <button mat-stroked-button routerLink="/push_setup"><mat-icon>notification_add</mat-icon> Notification Setup</button>
+        <button mat-stroked-button routerLink="/edit_contact_info"><mat-icon>alternate_email</mat-icon> Edit Contact Info</button>
+        <button mat-stroked-button routerLink="/settings"><mat-icon>manage_accounts</mat-icon> Account Settings</button>
+
+        <mat-card>
+          <mat-card-content style="margin-bottom: 0;">
+            <mat-form-field appearance="outline" style="width: 100%; margin-bottom: -20px;">
+              <mat-label>Status Message</mat-label>
+              <input matInput [(ngModel)]="info.statusMessage" placeholder="What's up?">
+              <button mat-icon-button matSuffix (click)="removeStatus()" [disabled]="!info.statusMessage">
+                <mat-icon>clear</mat-icon>
+              </button>
+            </mat-form-field>
+          </mat-card-content>
+          <mat-card-actions style="padding-top: 0; margin-top: 0px;">
+            <button mat-button class="small-card-action" (click)="updateStatus()">Update Status</button>
+          </mat-card-actions>
+        </mat-card>
+
+        <mat-card>
+          <mat-card-content>
+            <span style="margin-right: 10px; position: relative; top: 5px">
+              <mat-icon *ngIf="!info.doNotDisturb">notifications_active</mat-icon>
+              <mat-icon *ngIf="info.doNotDisturb">notifications_off</mat-icon>
+            </span>
+            <mat-slide-toggle color="accent" [(ngModel)]="info.doNotDisturb" (change)="updateDoNotDisturb()">"Do Not Disturb" is {{info.doNotDisturb ? 'on' : 'off'}}.</mat-slide-toggle>
+            <div *ngIf="info.doNotDisturb" style="padding-top: 5px;">
+              <mat-hint>You won't get Boop notifications, and your friends won't get notifications about you.</mat-hint>
+            </div>
+          </mat-card-content>
+        </mat-card>
+
+        <button mat-stroked-button color="warn" (click)="logout()"><mat-icon>logout</mat-icon> Log Out</button>
+      </div>
     </div>
 </ng-container>

--- a/frontend/src/app/components/home/home.component.scss
+++ b/frontend/src/app/components/home/home.component.scss
@@ -2,10 +2,21 @@
     font-size: x-large;
     padding-top: 5px;
     padding-bottom: 5px;
-    width: 80%;
+    width: 100%;
 }
 
 button {
     margin-bottom: 10px;
     text-align: left;
+}
+
+mat-card {
+    padding-top: 10px;
+    padding-bottom: 10px;
+    margin-bottom: 10px;
+}
+
+.small-card-action {
+    padding-left: 10px;
+    padding-right: 10px;
 }

--- a/frontend/src/app/components/home/home.component.ts
+++ b/frontend/src/app/components/home/home.component.ts
@@ -31,6 +31,7 @@ export class HomeComponent implements OnInit {
   }
 
   loadInfo(): void {
+    this.info = undefined;
     this.apiService.getJSON<HomeScreenInfoResponse>("http://localhost:3000/user_info/home_info")
       .then(info => {
         this.info = info;
@@ -39,6 +40,33 @@ export class HomeComponent implements OnInit {
         this.apiService.showErrorPopup(err);
         this.logout();
       });
+  }
+
+  updateStatus(): void {
+    this.apiService.putJSON<string, void>("http://localhost:3000/user_info/update_status", this.info!.statusMessage)
+      .then(() => {
+        const popupMessage = this.info!.statusMessage ? "Status updated" : "Status cleared";
+        this.snackBar.open(popupMessage, "Dismiss", { duration: 2500 });
+      })
+      .catch(err => {
+        this.apiService.showErrorPopup(err);
+        this.loadInfo();
+      });
+  }
+
+  updateDoNotDisturb(): void {
+    this.apiService.putJSON<boolean, void>(
+      "http://localhost:3000/user_info/update_do_not_disturb",
+      this.info!.doNotDisturb
+    ).catch(err => {
+      this.apiService.showErrorPopup(err);
+      this.loadInfo();
+    });
+  }
+
+  removeStatus(): void {
+    this.info!.statusMessage = "";
+    this.updateStatus();
   }
 
   logout(): void {

--- a/frontend/src/app/materialDependencies.ts
+++ b/frontend/src/app/materialDependencies.ts
@@ -12,6 +12,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 
 // include all of the material component modules that we use here to avoid cluttering the main AppModule
 export const materialModules = [
@@ -29,5 +30,6 @@ export const materialModules = [
   MatProgressBarModule,
   MatTooltipModule,
   MatToolbarModule,
+  MatSlideToggleModule
 ];
 

--- a/init.sql
+++ b/init.sql
@@ -19,7 +19,9 @@ CREATE TABLE users(
     friendly_name TEXT NOT NULL,
     gender GENDER_IDENTITY, -- allowed to be null for users who prefer not to state a gender
     email TEXT NOT NULL,
-    birth_date TEXT NOT NULL -- date in ISO format
+    birth_date TEXT NOT NULL, -- date in ISO format
+    status_message TEXT,
+    do_not_disturb BOOLEAN
 );
 
 -- only users listed here can use admin command endpoints

--- a/init.sql
+++ b/init.sql
@@ -19,16 +19,20 @@ CREATE TABLE users(
     friendly_name TEXT NOT NULL,
     gender GENDER_IDENTITY, -- allowed to be null for users who prefer not to state a gender
     email TEXT NOT NULL,
-    birth_date TEXT NOT NULL, -- date in ISO format
-    is_admin BOOLEAN
+    birth_date TEXT NOT NULL -- date in ISO format
 );
 
--- create special admin account for demonstrations
--- TODO remove this before deploying
+-- only users listed here can use admin command endpoints
+CREATE TABLE administrators(
+    admin_user_uuid UUID PRIMARY KEY REFERENCES users (user_uuid) ON DELETE CASCADE
+);
+
+-- create special admin account
 INSERT INTO users
-("user_uuid", "username", "bcrypt_hash", "full_name", "friendly_name", "gender", "email", "birth_date", "is_admin")
+("user_uuid", "username", "bcrypt_hash", "full_name", "friendly_name", "gender", "email", "birth_date")
 VALUES ('689b90d7-41ed-4257-a2a1-ca6d608d28f7', 'admin', '$2b$09$6Xjk49GbCZTjoognkzPk2.pyblewRbaiHLGap0PjETNNX924or4xS',
-'Boop Administrator', 'Administrator', null, 'example@example.com', '2000-01-15', TRUE);
+'Boop Administrator', 'Administrator', null, 'example@example.com', '2000-01-15');
+INSERT INTO administrators(admin_user_uuid) values ('689b90d7-41ed-4257-a2a1-ca6d608d28f7');
 
 -- web-push subscriptions and the associated users
 -- endpoint column ensures we don't send duplicate notifications to the same user on the same device/browser

--- a/initialize_examples.sql
+++ b/initialize_examples.sql
@@ -22,43 +22,43 @@ begin
     -- gpb (George P Burdell)
     INSERT INTO users
       ("user_uuid", "username", "bcrypt_hash", "full_name",
-      "friendly_name", "gender", "email", "birth_date", "is_admin")
+      "friendly_name", "gender", "email", "birth_date")
       VALUES (georgeUUID, 'gpb', example_password_hash, 'George P. Burdell',
-      'George', 'Male', 'gburdell@gatech.edu', '1909-04-01', false);
+      'George', 'Male', 'gburdell@gatech.edu', '1909-04-01');
     -- ramonac (Ramona Cartwright Burdell)
     INSERT INTO users
       ("user_uuid", "username", "bcrypt_hash", "full_name",
-      "friendly_name", "gender", "email", "birth_date", "is_admin")
+      "friendly_name", "gender", "email", "birth_date")
       VALUES (ramonaUUID, 'ramona', example_password_hash, 'Ramona Cartwright Burdell',
-      'Ramona', 'Female', 'rcartwright@agnesscott.edu', '1936-04-01', false);
+      'Ramona', 'Female', 'rcartwright@agnesscott.edu', '1936-04-01');
     -- JRainwater (John Rainwater)
     INSERT INTO users
     ("user_uuid", "username", "bcrypt_hash", "full_name",
-      "friendly_name", "gender", "email", "birth_date", "is_admin")
+      "friendly_name", "gender", "email", "birth_date")
       VALUES (johnUUID, 'JRainwater', example_password_hash, 'John Rainwater',
-      'Johnny', null, 'jrainwater@washington.edu', '1952-01-01', false);
+      'Johnny', null, 'jrainwater@washington.edu', '1952-01-01');
 
     -- alice, bob, charlie, and david
     INSERT INTO users
     ("user_uuid", "username", "bcrypt_hash", "full_name",
-      "friendly_name", "gender", "email", "birth_date", "is_admin")
+      "friendly_name", "gender", "email", "birth_date")
       VALUES (aliceUUID, 'alice', example_password_hash, 'Alice Exampleton',
-      'Alice', 'Female', 'alice@example.com', '1995-03-05', false);
+      'Alice', 'Female', 'alice@example.com', '1995-03-05');
     INSERT INTO users
     ("user_uuid", "username", "bcrypt_hash", "full_name",
-      "friendly_name", "gender", "email", "birth_date", "is_admin")
+      "friendly_name", "gender", "email", "birth_date")
       VALUES (bobUUID, 'bob', example_password_hash, 'Robert Defacto',
-      'Bob', null, 'bob@example.com', '1999-10-20', false);
+      'Bob', null, 'bob@example.com', '1999-10-20');
     INSERT INTO users
     ("user_uuid", "username", "bcrypt_hash", "full_name",
-      "friendly_name", "gender", "email", "birth_date", "is_admin")
+      "friendly_name", "gender", "email", "birth_date")
       VALUES (charlieUUID, 'charlie', example_password_hash, 'Charlie McExampleface',
-      'Charlie', 'Nonbinary', 'charlie@example.com', '2000-07-15', false);
+      'Charlie', 'Nonbinary', 'charlie@example.com', '2000-07-15');
     INSERT INTO users
     ("user_uuid", "username", "bcrypt_hash", "full_name",
-      "friendly_name", "gender", "email", "birth_date", "is_admin")
+      "friendly_name", "gender", "email", "birth_date")
       VALUES (davidUUID, 'david', example_password_hash, 'David Défaut',
-      'Dave', null, 'david@example.com', '1995-03-30', false);
+      'Dave', null, 'david@example.com', '1995-03-30');
 
 
     -- friend request from John Rainwater to George P Burdell


### PR DESCRIPTION
Two new controls on the home screen: "Do Not Disturb" and "Custom Status Messages".

Do not disturb allows users to temporarily opt out of receiving boop reminder push notifications, and as a result their friends/ friends-of-friends will not get notifications about them.

Status messages are short pieces of text that are displayed on the user's card in the friends page and will be included in their profile page.

This PR also makes some changes to how user accounts are represented in the database; there is now a separate table for keeping track of which users are administrators, so we don't have to have a column for it on every user account.

![image](https://user-images.githubusercontent.com/40121408/108011263-b415a780-6fd4-11eb-8f33-4fbcfbf4d0f0.png)

Resolves #32.
