### PR TITLE
show confirmation dialog before unfriending

### DIFF
--- a/frontend/src/app/components/friends/friends.component.html
+++ b/frontend/src/app/components/friends/friends.component.html
@@ -26,7 +26,7 @@
         <p style="margin-bottom: 0; margin-top: -10px;" *ngIf="friend.statusMessage"> <mat-icon style="position: relative; top: 7px;">sticky_note_2</mat-icon>“{{friend.statusMessage}}”</p>
       </div>
       <mat-card-actions style="padding-top: 0;">
-        <button mat-button (click)="unfriend(friend.uuid)" color="warn">UNFRIEND</button>
+        <button mat-button (click)="unfriend(friend)" color="warn">UNFRIEND</button>
       </mat-card-actions>
     </mat-card>
   </ng-container>

--- a/frontend/src/app/components/friends/friends.component.ts
+++ b/frontend/src/app/components/friends/friends.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { AnswerFriendRequest, GetFriendsResult, ProfileSummary } from 'boop-core';
 import { ApiService } from 'src/app/services/api.service';
+import { DialogService } from '../common/dialog/dialog.service';
 
 @Component({
   selector: 'app-add-friends',
@@ -14,7 +14,7 @@ export class FriendsComponent implements OnInit {
 
   constructor(
     private apiService: ApiService,
-    private snackBar: MatSnackBar
+    private dialogService: DialogService
   ) { }
 
   ngOnInit(): void {
@@ -41,16 +41,21 @@ export class FriendsComponent implements OnInit {
       });
   }
 
-  unfriend(friendUUID: string): void {
-    this.apiService.postJSON<string, void>(
-      "http://localhost:3000/friends/unfriend",
-      friendUUID
-    ).then(() => {
+  async showUnfriendDialog(friend: ProfileSummary): Promise<void> {
+    const confirmed = await this.dialogService.confirm({
+      title: "Confirm Unfriending",
+      body: `Are you sure you want to unfriend ${friend.fullName}?`,
+      confirmText: "Unfriend",
+      cancelText: "Cancel"
+    });
+    if (confirmed) {
+      await this.apiService.postJSON<string, void>("http://localhost:3000/friends/unfriend", friend.uuid);
       this.loadInfo();
-    })
-      .catch((err) => {
-        this.apiService.showErrorPopup(err);
-      });
+    }
+  }
+
+  unfriend(friend: ProfileSummary): void {
+    this.showUnfriendDialog(friend).catch(err => this.apiService.showErrorPopup(err));
   }
 
 


### PR DESCRIPTION
closes #25

it's important to have this finished in time for the demo video which we plan to record tomorrow. Porter was going to complete this issue but is having car trouble today, so I've taken the same modular dialog service that he created for the account-deletion feature and used it for confirming whether the user wants to unfriend someone.