### PR TITLE
add database columns for upcoming profiles feature

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -11,15 +11,22 @@ CREATE DATABASE boop
 
 CREATE TYPE GENDER_IDENTITY AS ENUM ('Female', 'Male', 'Nonbinary');
 
+-- public: profile and contact info visible to everyone
+-- private: profile and contact info visible to friends and friends-of-friends
+-- restricted: profile and contact info visible to friends only (disables notifications to talk to friends-of-friends)
+CREATE TYPE PRIVACY_LEVEL AS ENUM ('public', 'private', 'restricted');
+
 CREATE TABLE users(
     user_uuid UUID PRIMARY KEY,
     username TEXT NOT NULL UNIQUE,
-    bcrypt_hash TEXT NOT NULL, -- bcrypt "hashes" actually contain both the password hash and salt as one string
+    -- bcrypt "hashes" actually contain both the password hash and salt as one string
+    bcrypt_hash TEXT NOT NULL,
     full_name TEXT NOT NULL,
     friendly_name TEXT NOT NULL,
-    gender GENDER_IDENTITY, -- allowed to be null for users who prefer not to state a gender
+    -- gender is allowed to be null for users who prefer not to state a gender
+    gender GENDER_IDENTITY,
     email TEXT NOT NULL,
-    -- date in ISO format
+    -- date in ISO format, e.g. '2000-12-31'
     birth_date TEXT NOT NULL,
     status_message TEXT NOT NULL DEFAULT ''::TEXT,
     do_not_disturb BOOLEAN NOT NULL DEFAULT false,
@@ -27,7 +34,13 @@ CREATE TABLE users(
     -- note that the default value is equivilant to Jan 1 1970
     last_push_timestamp bigint NOT NULL DEFAULT 0,
     -- web-push/VAPID subscription objects used to send push notifications
-    vapid_subs JSONB[] NOT NULL DEFAULT '{}'::JSONB[]
+    vapid_subs JSONB[] NOT NULL DEFAULT '{}'::JSONB[],
+    -- profile privacy settings
+    profile_privacy_level PRIVACY_LEVEL NOT NULL DEFAULT 'public',
+    profile_show_age BOOLEAN NOT NULL DEFAULT true,
+    profile_show_gender BOOLEAN NOT NULL DEFAULT true,
+    -- profile page description field
+    profile_bio TEXT NOT NULL DEFAULT ''::TEXT
 );
 
 -- only users listed here can use admin command endpoints
@@ -44,16 +57,21 @@ INSERT INTO administrators(admin_user_uuid) values ('689b90d7-41ed-4257-a2a1-ca6
 
 -- user log-in sessions
 CREATE TABLE sessions(
+    -- a unique token is randomly generated for each session
     token text PRIMARY KEY,
     user_uuid UUID NOT NULL REFERENCES users (user_uuid) ON DELETE CASCADE,
-    time_last_touched bigint NOT NULL -- time this session was last accessed, in milliseconds since epoch
+    -- time this session was last accessed, in milliseconds since epoch
+    time_last_touched bigint NOT NULL
 );
 
 -- identifies a reminder push notification and authorizes getting user info about the target friend or friend-of-friend
 CREATE TABLE push_identity_tokens(
+    -- each chat prompt notification has a token that is separate from the session tokens
     token text PRIMARY KEY,
+    -- uuid of the user whose information will be shown on "start chat" page for this notification
     target_user_uuid UUID NOT NULL REFERENCES users (user_uuid) ON DELETE CASCADE,
-    expiration_time bigint NOT NULL -- expiration time in milliseconds since epoch
+    -- expiration time in milliseconds since epoch
+    expiration_time bigint NOT NULL
 );
 
 -- pending friend requests
@@ -71,5 +89,6 @@ CREATE TABLE friends(
 CREATE TABLE contact_methods(
     user_uuid UUID NOT NULL REFERENCES users (user_uuid) ON DELETE CASCADE,
     platform TEXT NOT NULL,
-    contact_id TEXT NOT NULL -- user's username/number/etc for that platform
+    -- user's username/number/etc for that platform
+    contact_id TEXT NOT NULL
 );

--- a/initialize_examples.sql
+++ b/initialize_examples.sql
@@ -19,55 +19,44 @@ declare
   eveUUID UUID := '0000000e-0000-0000-0000-000000000000';
 
 begin
-    -- add example users'
+    INSERT INTO users
+      ("user_uuid", "username", "full_name", "friendly_name", "bcrypt_hash",
+      "email", "gender", "birth_date",
+      "profile_privacy_level", "profile_show_age", "profile_show_gender", "profile_bio") VALUES
     -- gpb (George P Burdell)
-    INSERT INTO users
-      ("user_uuid", "username", "bcrypt_hash", "full_name",
-      "friendly_name", "gender", "email", "birth_date")
-      VALUES (georgeUUID, 'gpb', example_password_hash, 'George P. Burdell',
-      'George', 'Male', 'gburdell@gatech.edu', '1909-04-01');
-    -- ramonac (Ramona Cartwright Burdell)
-    INSERT INTO users
-      ("user_uuid", "username", "bcrypt_hash", "full_name",
-      "friendly_name", "gender", "email", "birth_date")
-      VALUES (ramonaUUID, 'ramona', example_password_hash, 'Ramona Cartwright Burdell',
-      'Ramona', 'Female', 'rcartwright@agnesscott.edu', '1936-04-01');
+    (georgeUUID, 'gpb', 'Geore P. Budell', 'George', example_password_hash,
+    'gburdell@gatech.edu', 'Male', '1909-04-01',
+    'private', false, true, 'The Eternal Georgia Tech Student. Go Jackets!'),
+    -- ramona (Ramona Cartwright Burdell)
+    (ramonaUUID, 'ramona', 'Ramona Cartwright Burdell', 'Ramona', example_password_hash,
+    'rcartwright@agnesscott.edu', 'Female', '1936-04-01',
+    'public', true, true, 'Fictitious Scottie'),
     -- JRainwater (John Rainwater)
-    INSERT INTO users
-    ("user_uuid", "username", "bcrypt_hash", "full_name",
-      "friendly_name", "gender", "email", "birth_date")
-      VALUES (johnUUID, 'JRainwater', example_password_hash, 'John Rainwater',
-      'Johnny', null, 'jrainwater@washington.edu', '1952-01-01');
+    (johnUUID, 'JRainwater', 'John Rainwater', 'Johnny', example_password_hash,
+    'jrainwater@washington.edu', null, '1952-01-01',
+    'public', true, true, 'Mathematician specializing in Functional Analysis.'),
+    -- alice
+    (aliceUUID, 'alice', 'Alice Exampelton', 'Alice', example_password_hash,
+    'alice@example.com', 'Female', '1995-03-05',
+    'public', true, true, 'Cryptography Enthusiast'),
+    -- bob
+    (bobUUID, 'bob', 'Robert Defacto', 'Bob', example_password_hash,
+    'bob@example.com', 'Male', '1990-10-20',
+    'private', false, false, 'Proponent of public-key encryption'),
+    -- charlie
+    (charlieUUID, 'charlie', 'Charlie McExampleFace', 'Charlie', example_password_hash,
+    'charlie@example.com', 'Nonbinary', '2000-07-15',
+    'public', false, true, ''),
+    -- david
+    (davidUUID, 'david', 'David Défaut', 'Dave', example_password_hash,
+    'david@example.com', null, '1995-03-30',
+    'public', true, true, ''),
+    -- eve
+    (eveUUID, 'eve', 'Eve Exampleton', 'Eve', example_password_hash,
+    'eve@example.com', 'Female', '1996-07-17',
+    'private', true, true, '');
 
-    -- alice, bob, charlie, and david
-    INSERT INTO users
-    ("user_uuid", "username", "bcrypt_hash", "full_name",
-      "friendly_name", "gender", "email", "birth_date")
-      VALUES (aliceUUID, 'alice', example_password_hash, 'Alice Exampleton',
-      'Alice', 'Female', 'alice@example.com', '1995-03-05');
-    INSERT INTO users
-    ("user_uuid", "username", "bcrypt_hash", "full_name",
-      "friendly_name", "gender", "email", "birth_date")
-      VALUES (bobUUID, 'bob', example_password_hash, 'Robert Defacto',
-      'Bob', 'Male', 'bob@example.com', '1999-10-20');
-    INSERT INTO users
-    ("user_uuid", "username", "bcrypt_hash", "full_name",
-      "friendly_name", "gender", "email", "birth_date")
-      VALUES (charlieUUID, 'charlie', example_password_hash, 'Charlie McExampleface',
-      'Charlie', 'Nonbinary', 'charlie@example.com', '2000-07-15');
-    INSERT INTO users
-    ("user_uuid", "username", "bcrypt_hash", "full_name",
-      "friendly_name", "gender", "email", "birth_date")
-      VALUES (davidUUID, 'david', example_password_hash, 'David Défaut',
-      'Dave', null, 'david@example.com', '1995-03-30');
-    INSERT INTO users
-    ("user_uuid", "username", "bcrypt_hash", "full_name",
-      "friendly_name", "gender", "email", "birth_date")
-      VALUES (eveUUID, 'eve', example_password_hash, 'Eve Exampleton',
-      'Eve', 'Female', 'eve@example.com', '1996-07-17');
-
-
-    -- friend request from John Rainwater to George P Burdell
+    -- friend requests
     insert into friend_requests(from_user, to_user)
         values(johnUUID, georgeUUID);
 
@@ -88,7 +77,7 @@ begin
 
     -- contact methods
     INSERT INTO contact_methods (user_uuid, platform, contact_id) VALUES
-    (georgeUUID, 'WhatsApp', '15555555555'),
+    (georgeUUID, 'WhatsApp', '+1-555-555-5555'),
     (georgeUUID, 'Discord', 'burdell#1234'),
     (georgeUUID, 'iMessage', '555-555-5555'),
     (ramonaUUID, 'WhatsApp', '15555551234'),

--- a/initialize_examples.sql
+++ b/initialize_examples.sql
@@ -1,12 +1,12 @@
--- script to set up example data for testing. do not use in production.
+-- DO NOT USE IN PRODUCTION. script to set up example data for testing.
 
 \c boop;
 
 do $$
 <<examples>>
 declare
-  -- all of these test accounts use the password "foobar", which matches this hash
-  example_password_hash TEXT := '$2b$09$lAAPQpGfr7wG/D9KzFX1pOTrNpgX5X5AOCunbTxfOdcdmyqnKgOPy';
+  -- all of these test accounts use the password 'beepboob', which matches this hash
+  example_password_hash TEXT := '$2b$09$CNpJ2n9Tgz8Qgz0EbXfXg.ImFxY3A0sP0o3.alzzgAsxLm47O.rJm';
 
   -- fake UUIDs
   georgeUUID UUID := '00000001-0000-0000-0000-000000000000';


### PR DESCRIPTION
we have an upcoming assignment to create an ERD of our database, so to make that easier, this should be more-or-less the final version of our database tables. I've added a column for the profile bio and some columns for determining what information to show and who can see it.

There might be changes to the database to add procedures or expand enum options, but this should hopefully be the final version of the columns.

I also improved the comments in `init.sql` and changed the example users' passwords to avoid the chrome password leak popup (the example accounts should never be used in production).