### PR TITLE
Privacy settings

### DIFF
--- a/backend/src/queries/accountQueries.ts
+++ b/backend/src/queries/accountQueries.ts
@@ -1,21 +1,24 @@
-import { CreateAccountRequest, Gender, genderValues, LoginResponse, UpdateAccountRequest,
+import { CreateAccountRequest, Gender, genderValues, UpdateAccountRequest,
   CurrentSettingsResponse, PrivacyLevel } from "boop-core";
 import { database } from "../services/database";
 import { v4 as uuidv4 } from 'uuid';
-import { hashPassword, login, } from "../services/auth";
+import { hashPassword } from "../services/auth";
 import { throwBoopError } from "../util/handleAsync";
 import { emailToGravatarURL } from "../services/avatars";
 
-export async function createAccount(request: CreateAccountRequest): Promise<LoginResponse> {
+export async function createAccount(request: CreateAccountRequest): Promise<void> {
   const accountUUID = uuidv4();
   const passwordHash = await hashPassword(request.password);
 
   const query =
       `INSERT INTO users
-      ("user_uuid", "username", "bcrypt_hash", "full_name", "friendly_name", "gender", "email", "birth_date")
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8);`;
-  const params = [accountUUID, request.username, passwordHash, request.fullName, request.friendlyName,
-    request.gender, request.emailAddress, request.birthDate];
+      ("user_uuid", "username", "bcrypt_hash", "full_name", "friendly_name", "gender",
+      "email", "birth_date", "profile_privacy_level", "profile_show_age", "profile_show_gender")
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11);`;
+  const params = [
+    accountUUID, request.username, passwordHash, request.fullName, request.friendlyName, request.gender,
+    request.emailAddress, request.birthDate, request.privacyLevel, request.profileShowAge, request.profileShowGender
+  ];
 
   try {
     await database.query(query, params);
@@ -26,8 +29,6 @@ export async function createAccount(request: CreateAccountRequest): Promise<Logi
       throw err;
     }
   }
-
-  return await login({ username: request.username, password: request.password });
 }
 
 

--- a/backend/src/queries/accountQueries.ts
+++ b/backend/src/queries/accountQueries.ts
@@ -1,5 +1,5 @@
 import { CreateAccountRequest, Gender, genderValues, LoginResponse, UpdateAccountRequest,
-  UserAccountResponse } from "boop-core";
+  CurrentSettingsResponse, PrivacyLevel } from "boop-core";
 import { database } from "../services/database";
 import { v4 as uuidv4 } from 'uuid';
 import { hashPassword, login, } from "../services/auth";
@@ -59,9 +59,11 @@ export async function deleteAccount(uuid: string): Promise<void> {
   await database.query(query, [uuid]); // Any error should be thrown
 }
 
-export async function getUserAccount(uuid: string): Promise<UserAccountResponse> {
-  const query = `SELECT "username", "full_name", "friendly_name", "email", "birth_date", "gender"
-   FROM users WHERE user_uuid=$1`;
+export async function getCurrentSettings(uuid: string): Promise<CurrentSettingsResponse> {
+  const query =
+  `SELECT "username", "full_name", "friendly_name", "email", "birth_date", "gender",
+    "profile_privacy_level", "profile_show_age","profile_show_gender"
+    FROM users WHERE user_uuid=$1`;
   type UserRow = {
     username: string;
     full_name: string;
@@ -69,15 +71,14 @@ export async function getUserAccount(uuid: string): Promise<UserAccountResponse>
     email: string;
     birth_date: string;
     gender: Gender;
+    profile_privacy_level: PrivacyLevel;
+    profile_show_age: boolean;
+    profile_show_gender: boolean;
   };
 
   const rows: UserRow[] = (await database.query(query, [uuid]));
+  const result = rows[0] ?? throwBoopError("Account Not Found", 404);
 
-  if (rows.length === 0) {
-    throwBoopError("Account Not Found", 404);
-  }
-
-  const result = rows[0];
   return {
     username: result.username,
     fullName: result.full_name,
@@ -86,6 +87,9 @@ export async function getUserAccount(uuid: string): Promise<UserAccountResponse>
     birthDate: result.birth_date,
     gender: result.gender,
     avatarUrl: emailToGravatarURL(result.email),
+    privacyLevel: result.profile_privacy_level,
+    profileShowAge: result.profile_show_age,
+    profileShowGender: result.profile_show_gender
   };
 }
 

--- a/backend/src/queries/reminderQueries.ts
+++ b/backend/src/queries/reminderQueries.ts
@@ -10,160 +10,79 @@ import webpush from "web-push";
 const pushTokenExpirationTime = 7 * 24 * 60 * 60 * 1000;
 
 export async function selectPairs(): Promise<Pairing[]> {
-  const query =
-    `-- find all the users that can be sent notifications right now
-    WITH enabled_users AS (
-      SELECT user_uuid
-      FROM users
-      WHERE (do_not_disturb IS NOT true) and (last_push_timestamp is null or last_push_timestamp < $1)
-    ),
-    -- users with restricted profiles cannot match with friends-of-friends
-	  restricted_users AS (
-		  select user_uuid from users where profile_privacy_level = 'restricted'
-	  ),
-    -- find all the friend-of-friend relationships that don't include someone with a restricted profile
-    metafriends as (
-      select f1.user_a as user_a, f1.user_b as shared, f2.user_b as user_b
-      from friends f1 join friends f2 on f1.user_b = f2.user_a
-      where f1.user_a <> f2.user_b and f2.user_b not in (select f3.user_b from friends f3 where f3.user_a = f1.user_a)
-		and f1.user_a not in (select user_uuid from restricted_users)
-		and f2.user_b not in (select user_uuid from restricted_users)
-    ),
-    -- pick a random subset of users to get notifications about friends
-    friends_chosen_users AS (
-      SELECT user_uuid
-      FROM enabled_users
-      WHERE random() < $2
-    ),
-    -- get the array of possible friends that those users could be paired with
-    friend_options AS (
-      SELECT user_a, array_agg(user_b order by random()) as user_bs
-      FROM friends_chosen_users join friends on friends_chosen_users.user_uuid = friends.user_a
-      group by user_a
-    ),
-    -- pick a random subset of users to get notifications about friends-of-friends
-    metafriends_chosen_users AS (
-      SELECT user_uuid
-      FROM enabled_users
-      WHERE random() < $3
-    ),
-    -- get the array of possible friends-of-friends those users could be paired with
-    metafriend_options AS (
-      SELECT user_a, array_agg(ARRAY[user_b, shared] order by random()) as user_bs
-      FROM metafriends_chosen_users join metafriends on metafriends_chosen_users.user_uuid = metafriends.user_a
-      group by user_a
-    ),
-    friend_pairs as (
-      -- select one of the possible friends
-      select user_a, user_bs[1] as user_b, NULL::UUID as shared
-      from friend_options
-      -- note that the resulting set of pairs is likely to contain duplicates of the same user
-    ),
-    metafriend_pairs as (
-      select user_a, user_bs[1][1] as user_b, user_bs[1][2] as shared
-      from metafriend_options
-      -- note that the resulting set of pairs is likely to contain duplicates of the same user
-    ),
-    -- merge friend pairs and friend-of-friend pairs
-    all_pairs as (
-      select * from friend_pairs union all select * from metafriend_pairs
-    ),
-    -- collect user info for user a
-    a_info as (
-      select user_a, user_b, shared,
-      full_name as full_name_a, friendly_name as friendly_name_a, gender as gender_a, vapid_subs as vapid_subs_a
-      from all_pairs join users on user_a = user_uuid
-    ),
-    -- collect user info for user b
-    ab_info as (
-      select user_a, user_b, shared,
-      full_name_a, friendly_name_a, gender_a, vapid_subs_a,
-      full_name as full_name_b, friendly_name as friendly_name_b, gender as gender_b, vapid_subs as vapid_subs_b
-      from a_info join users on user_b = user_uuid
-    ),
-    -- collect user info for mutual friend if applicable
-    abc_info as (
-      select user_a, user_b,
-      full_name_a, friendly_name_a, gender_a, vapid_subs_a,
-      full_name_b, friendly_name_b, gender_b, vapid_subs_b,
-      full_name as mutual_full_name, friendly_name as mutual_friendly_name, gender as mutual_gender
-      from ab_info left join users on shared = user_uuid
-    )
-    -- return results in a random order
-    select * from abc_info order by random();`;
-
+  // mutual friend columns are null for friend pairs
+  type PairRow = {
+    user_a: string; user_b: string;
+    full_name_a: string; friendly_name_a: string; gender_a: Gender; vapid_subs_a: webpush.PushSubscription[];
+    full_name_b: string; friendly_name_b: string; gender_b: Gender; vapid_subs_b: webpush.PushSubscription[];
     // mutual friend columns are null for friend pairs
-    type PairRow = {
-      user_a: string; user_b: string;
-      full_name_a: string; friendly_name_a: string; gender_a: Gender; vapid_subs_a: webpush.PushSubscription[];
-      full_name_b: string; friendly_name_b: string; gender_b: Gender; vapid_subs_b: webpush.PushSubscription[];
-      // mutual friend columns are null for friend pairs
-      mutual_full_name: string | null; mutual_friendly_name: string | null; mutual_gender: Gender | null;
-    };
-    const rows: PairRow[] = await database.query(query, [
-      Date.now() - scheduleParameters.cooldown,
-      scheduleParameters.friendProbability,
-      scheduleParameters.metafriendProbability]
-    );
+    mutual_full_name: string | null; mutual_friendly_name: string | null; mutual_gender: Gender | null;
+  };
+  // call selectPairs SQL function defined in init.sql
+  const rows: PairRow[] = await database.query(`select * from selectPairs($1, $2, $3)`, [
+    Date.now() - scheduleParameters.cooldown,
+    scheduleParameters.friendProbability,
+    scheduleParameters.metafriendProbability]
+  );
 
-    const pairings: Pairing[] = [];
-    // we skip any pairings with users that are already included in this iteration.
-    const usedUsers: Set<string> = new Set([]);
-    for (const row of rows) {
-      if (!usedUsers.has(row.user_a) && !usedUsers.has(row.user_b)) {
-        usedUsers.add(row.user_a);
-        usedUsers.add(row.user_b);
+  const pairings: Pairing[] = [];
+  // we skip any pairings with users that are already included in this iteration.
+  const usedUsers: Set<string> = new Set([]);
+  for (const row of rows) {
+    if (!usedUsers.has(row.user_a) && !usedUsers.has(row.user_b)) {
+      usedUsers.add(row.user_a);
+      usedUsers.add(row.user_b);
 
-        pairings.push(row.mutual_full_name === null
-          ? {
-            friends: true,
-            userA: {
-              uuid: row.user_a,
-              fullName: row.full_name_a,
-              friendlyName: row.friendly_name_a,
-              gender: row.gender_a,
-              vapidSubs: row.vapid_subs_a
-            },
-            userB: {
-              uuid: row.user_b,
-              fullName: row.full_name_b,
-              friendlyName: row.friendly_name_b,
-              gender: row.gender_b,
-              vapidSubs: row.vapid_subs_b
-            }
+      pairings.push(row.mutual_full_name === null
+        ? {
+          friends: true,
+          userA: {
+            uuid: row.user_a,
+            fullName: row.full_name_a,
+            friendlyName: row.friendly_name_a,
+            gender: row.gender_a,
+            vapidSubs: row.vapid_subs_a
+          },
+          userB: {
+            uuid: row.user_b,
+            fullName: row.full_name_b,
+            friendlyName: row.friendly_name_b,
+            gender: row.gender_b,
+            vapidSubs: row.vapid_subs_b
           }
-          : {
-            friends: false,
-            userA: {
-              uuid: row.user_a,
-              fullName: row.full_name_a,
-              friendlyName: row.friendly_name_a,
-              gender: row.gender_a,
-              vapidSubs: row.vapid_subs_a
-            },
-            userB: {
-              uuid: row.user_b,
-              fullName: row.full_name_b,
-              friendlyName: row.friendly_name_b,
-              gender: row.gender_b,
-              vapidSubs: row.vapid_subs_b
-            },
-            mutualFriend: {
-              fullName: row.mutual_full_name,
-              friendlyName: row.mutual_friendly_name!,
-              gender: row.mutual_gender
-            }
-          });
-      }
+        }
+        : {
+          friends: false,
+          userA: {
+            uuid: row.user_a,
+            fullName: row.full_name_a,
+            friendlyName: row.friendly_name_a,
+            gender: row.gender_a,
+            vapidSubs: row.vapid_subs_a
+          },
+          userB: {
+            uuid: row.user_b,
+            fullName: row.full_name_b,
+            friendlyName: row.friendly_name_b,
+            gender: row.gender_b,
+            vapidSubs: row.vapid_subs_b
+          },
+          mutualFriend: {
+            fullName: row.mutual_full_name,
+            friendlyName: row.mutual_friendly_name!,
+            gender: row.mutual_gender
+          }
+        });
     }
-    // update timestamps on all selected users
-    if (usedUsers.size > 0) {
-      await database.query(
-        pgFormat('UPDATE users set last_push_timestamp=$1 where user_uuid in (%L);', [...usedUsers.values()]),
-        [Date.now()]
-      );
-    }
-    return pairings;
+  }
+  // update timestamps on all selected users
+  if (usedUsers.size > 0) {
+    await database.query(
+      pgFormat('UPDATE users set last_push_timestamp=$1 where user_uuid in (%L);', [...usedUsers.values()]),
+      [Date.now()]
+    );
+  }
+  return pairings;
 }
 
 export async function createNotificationTokens(pair: Pairing): Promise<{tokenToA: string; tokenToB: string;}> {

--- a/backend/src/routers/accountsRouter.ts
+++ b/backend/src/routers/accountsRouter.ts
@@ -8,7 +8,9 @@ import { CreateAccountRequest, minYearsAgo, isGender } from "boop-core";
 import { handleAsync, throwBoopError } from "../util/handleAsync";
 import { getAuthInfoByUsername, getPasswordHashByUuid, removeSession } from "../queries/authQueries";
 import bcrypt from "bcrypt";
-import { createAccount, getCurrentSettings, updateAccount, updatePassword, deleteAccount } from "../queries/accountQueries";
+import {
+  createAccount, getCurrentSettings, updateAccount, updatePassword, deleteAccount
+} from "../queries/accountQueries";
 import { database } from "../services/database";
 
 export const accountsRouter = express.Router();
@@ -50,7 +52,8 @@ accountsRouter.post('/register', handleAsync(async (req, res) => {
     throwBoopError("Invalid gender format.", 400);
   }
 
-  const loginResponse: LoginResponse = await createAccount(body);
+  await createAccount(body);
+  const loginResponse: LoginResponse = await login({ username: body.username, password: body.password });
   res.send(loginResponse);
 }));
 

--- a/core/src/datatypes/account.ts
+++ b/core/src/datatypes/account.ts
@@ -1,6 +1,7 @@
 // data for account creation
 
 import { Gender } from "./gender";
+import { PrivacyLevel } from "./profile";
 
 export type CreateAccountRequest = {
   username: string;
@@ -21,7 +22,7 @@ export type UpdateAccountRequest = {
   gender: Gender;
 };
 
-export type UserAccountResponse = {
+export type CurrentSettingsResponse = {
   username: string;
   fullName: string;
   friendlyName: string;
@@ -29,6 +30,9 @@ export type UserAccountResponse = {
   birthDate: string;
   gender: Gender;
   avatarUrl: string;
+  privacyLevel: PrivacyLevel;
+  profileShowAge: boolean;
+  profileShowGender: boolean;
 };
 
 export type UpdatePasswordRequest = {
@@ -36,4 +40,8 @@ export type UpdatePasswordRequest = {
   newPassword: string;
 };
 
-
+export type UpdatePrivacyRequest = {
+  privacyLevel: PrivacyLevel;
+  profileShowAge: boolean;
+  profileShowGender: boolean;
+};

--- a/core/src/datatypes/account.ts
+++ b/core/src/datatypes/account.ts
@@ -11,6 +11,9 @@ export type CreateAccountRequest = {
   emailAddress: string;
   birthDate: string; // ISO format date string (e.g. 2020-01-16)
   gender: Gender;
+  privacyLevel: PrivacyLevel;
+  profileShowAge: boolean;
+  profileShowGender: boolean;
 };
 
 export type UpdateAccountRequest = {

--- a/core/src/datatypes/profile.ts
+++ b/core/src/datatypes/profile.ts
@@ -28,3 +28,7 @@ export type StartChatResult = {
   avatarUrl: string;
   contactMethods: ContactMethod[];
 };
+
+// private profiles are visible to friends and friends-of-friends
+// restricted profiles are visible only to friends, which prevents friends-of-friends from being matched
+export type PrivacyLevel = "public" | "private" | "restricted";

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -30,6 +30,7 @@ import { ChatComponent } from './components/chat/chat.component';
 import { DialogComponent } from './components/common/dialog/dialog.component';
 import { DialogService } from './components/common/dialog/dialog.service';
 import { AvatarOnboardingComponent } from './components/onboarding/avatar-onboarding/avatar-onboarding.component';
+import { PrivacyControlsComponent } from './components/settings/privacy-controls/privacy-controls.component';
 
 
 /* eslint-disable @typescript-eslint/no-extraneous-class */
@@ -53,6 +54,7 @@ import { AvatarOnboardingComponent } from './components/onboarding/avatar-onboar
     ChatComponent,
     DialogComponent,
     AvatarOnboardingComponent,
+    PrivacyControlsComponent,
   ],
   imports: [
     BrowserModule,

--- a/frontend/src/app/components/friends/friends.component.scss
+++ b/frontend/src/app/components/friends/friends.component.scss
@@ -5,6 +5,5 @@ mat-card {
 
 .section-header {
     margin-bottom: 0;
-    margin-top: 10px;
     text-align: center;
 }

--- a/frontend/src/app/components/landing/register/register.component.html
+++ b/frontend/src/app/components/landing/register/register.component.html
@@ -43,6 +43,9 @@
             <mat-datepicker #picker startView="multi-year" ></mat-datepicker>
         </mat-form-field>
     </div>
+    <div style="width: 80%; margin: auto; margin-top: 5px;">
+        <app-privacy-controls [formGroup]="registerForm"></app-privacy-controls>
+    </div>
     <div class="horizontal-center">
         <div style="width: 80%; display: flex; flex-direction: row; margin-top: 2px;">
             <mat-checkbox color="primary" formControlName="agreeToTerms"></mat-checkbox>
@@ -52,9 +55,8 @@
                 <button mat-button type="button" class="inline-button" color="primary" (click)="showTermsAndConditions()">User Agreement</button>
             </p>
         </div>
-
     </div>
-    <div style="text-align: center;">
+    <div style="text-align: center; padding-bottom: 15px;">
         <button mat-stroked-button type="button" style="width: calc(40% - 5px); margin-right: 10px;" color="warn"
             (click)="cancelRegistration.emit()">Back</button>
         <button mat-flat-button color="primary" style="width: calc(40% - 5px); "

--- a/frontend/src/app/components/landing/register/register.component.scss
+++ b/frontend/src/app/components/landing/register/register.component.scss
@@ -2,7 +2,7 @@ mat-form-field {
     min-width: 80%;
 }
 
-::ng-deep mat-card {
-    margin-bottom: 10px !important;
+:host ::ng-deep mat-card {
     margin: auto;
+    margin-bottom: 15px;
 }

--- a/frontend/src/app/components/landing/register/register.component.scss
+++ b/frontend/src/app/components/landing/register/register.component.scss
@@ -1,3 +1,8 @@
 mat-form-field {
     min-width: 80%;
 }
+
+::ng-deep mat-card {
+    margin-bottom: 10px !important;
+    margin: auto;
+}

--- a/frontend/src/app/components/landing/register/register.component.ts
+++ b/frontend/src/app/components/landing/register/register.component.ts
@@ -22,11 +22,17 @@ export class RegisterComponent implements OnInit {
   genderOptions: Gender[] = genderValues;
 
   registerForm: FormGroup = new FormGroup({
+    // user info
     fullName: new FormControl('', [Validators.required]),
     friendlyName: new FormControl('', [Validators.required]),
     email: new FormControl('', [Validators.required, Validators.email]),
     birthDate: new FormControl('', [Validators.required]),
     gender: new FormControl(),
+    // privacy settings
+    privacyLevel: new FormControl('public', [Validators.required]),
+    showAge: new FormControl(true, [Validators.required]),
+    showGender: new FormControl(true, [Validators.required]),
+    // user must check box to agree to terms
     agreeToTerms: new FormControl(false, [Validators.requiredTrue]),
   });
 
@@ -44,9 +50,7 @@ export class RegisterComponent implements OnInit {
 
   register(): void {
     const value = this.registerForm.value;
-    const fullName: string = value.fullName;
-    const friendlyName: string = value.friendlyName;
-    const emailAddress: string = value.email;
+
     // form value for gender is empty string if user chose "prefer not so say", or undefined if they did not choose
     // in either of those cases, we replace that with null
     const gender: Gender = value.gender || null;
@@ -59,11 +63,14 @@ export class RegisterComponent implements OnInit {
     const request: CreateAccountRequest = {
       username: this.credentials!.username,
       password: this.credentials!.password,
-      fullName,
-      friendlyName,
-      emailAddress,
+      fullName: value.fullName,
+      friendlyName: value.friendlyName,
+      emailAddress: value.email,
       gender,
       birthDate,
+      privacyLevel: value.privacyLevel,
+      profileShowAge: value.showAge,
+      profileShowGender: value.showGender,
     };
     this.sessionService.loginNewAccount(request).then(() => {
       void this.router.navigate(["/onboarding"]);

--- a/frontend/src/app/components/onboarding/avatar-onboarding/avatar-onboarding.component.html
+++ b/frontend/src/app/components/onboarding/avatar-onboarding/avatar-onboarding.component.html
@@ -9,6 +9,6 @@
             <a href="//gravatar.com" target="_blank" mat-raised-button  style="width: 100%;">Upload an image on gravatar.com <mat-icon>launch</mat-icon></a>
             <button mat-raised-button color="primary" style="width: 100%; margin-top: 20px;" (click)="done.emit();">Continue</button>
         </div>
-        <p style="opacity: 50%; margin-top: 20px; max-width: 2.6in;" class="menu-paragraph">It might around one minute for Gravatar changes to be applied</p>
+        <p style="opacity: 50%; margin-top: 20px; max-width: 2.6in;" class="menu-paragraph">It might take around one minute for Gravatar changes to be applied</p>
     </div>
 </ng-container>

--- a/frontend/src/app/components/onboarding/avatar-onboarding/avatar-onboarding.component.ts
+++ b/frontend/src/app/components/onboarding/avatar-onboarding/avatar-onboarding.component.ts
@@ -1,5 +1,5 @@
 import { Component, EventEmitter, OnInit, Output } from '@angular/core';
-import { UserAccountResponse } from 'boop-core';
+import { CurrentSettingsResponse } from 'boop-core';
 import { ApiService } from 'src/app/services/api.service';
 
 @Component({
@@ -9,7 +9,7 @@ import { ApiService } from 'src/app/services/api.service';
 })
 export class AvatarOnboardingComponent implements OnInit {
 
-  info: UserAccountResponse | undefined;
+  info: CurrentSettingsResponse | undefined;
 
   @Output() done = new EventEmitter<void>();
 
@@ -23,7 +23,7 @@ export class AvatarOnboardingComponent implements OnInit {
 
   refresh(): void {
     this.info = undefined;
-    this.apiService.getJSON<UserAccountResponse>("http://localhost:3000/account/info", undefined)
+    this.apiService.getJSON<CurrentSettingsResponse>("http://localhost:3000/account/current_settings", undefined)
       .then((response) => {
         this.info = response;
       })

--- a/frontend/src/app/components/settings/privacy-controls/privacy-controls.component.html
+++ b/frontend/src/app/components/settings/privacy-controls/privacy-controls.component.html
@@ -1,8 +1,8 @@
 <form [formGroup]="formGroup" *ngIf="formGroup">
-    <mat-card style="margin-bottom: 30px;">
+    <mat-card>
         <mat-card-header>
             <mat-card-title>Profile Privacy</mat-card-title>
-            <mat-card-subtitle>Control who can see your profile</mat-card-subtitle>
+            <mat-card-subtitle>Control who can see your profile, friends list, and contact info</mat-card-subtitle>
         </mat-card-header>
         <mat-card-content style="padding-left: 16px;">
             <mat-radio-group #privacySelection formControlName="privacyLevel" class="stacked-radio-group">
@@ -21,7 +21,7 @@
             </div>
         </mat-card-content>
     </mat-card>
-    <mat-card style="margin-bottom: 30px;">
+    <mat-card>
         <mat-card-header>
             <mat-card-title>Profile Information</mat-card-title>
             <mat-card-subtitle>Control what information is shown on your profile</mat-card-subtitle>

--- a/frontend/src/app/components/settings/privacy-controls/privacy-controls.component.html
+++ b/frontend/src/app/components/settings/privacy-controls/privacy-controls.component.html
@@ -1,0 +1,37 @@
+<form [formGroup]="formGroup" *ngIf="formGroup">
+    <mat-card style="margin-bottom: 30px;">
+        <mat-card-header>
+            <mat-card-title>Profile Privacy</mat-card-title>
+            <mat-card-subtitle>Control who can see your profile</mat-card-subtitle>
+        </mat-card-header>
+        <mat-card-content style="padding-left: 16px;">
+            <mat-radio-group #privacySelection formControlName="privacyLevel" class="stacked-radio-group">
+                <mat-radio-button class="stacked-radio-button" color=primary value="public"> <mat-icon>public</mat-icon><span>Everyone</span></mat-radio-button>
+                <mat-radio-button class="stacked-radio-button" color=primary value="private"><mat-icon>groups</mat-icon><span>Friends and Friends-of-Friends</span></mat-radio-button>
+                <mat-radio-button class="stacked-radio-button" color=primary value="restricted"><mat-icon>lock</mat-icon><span>Friends Only</span></mat-radio-button>
+            </mat-radio-group>
+            <div *ngIf="formGroup?.value.privacyLevel === 'restricted'"
+                style="display: flex; flex-direction: row; align-items: center; margin-top: 0.5em; margin-left: 5px; opacity: 50%;">
+
+                <mat-icon style="position: relative; bottom: 5px; margin-left: 5px;">warning</mat-icon>
+                <span>
+                    You will not get Boop notifications about friends-of-friends when your profile is restricted.
+                </span>
+
+            </div>
+        </mat-card-content>
+    </mat-card>
+    <mat-card style="margin-bottom: 30px;">
+        <mat-card-header>
+            <mat-card-title>Profile Information</mat-card-title>
+            <mat-card-subtitle>Control what information is shown on your profile</mat-card-subtitle>
+        </mat-card-header>
+        <mat-card-content style="padding-left: 16px;">
+            <div style="display: flex; flex-direction: column;">
+                <mat-slide-toggle color="primary" formControlName="showGender">Show gender</mat-slide-toggle>
+                <mat-slide-toggle color="primary" formControlName="showAge">Show age</mat-slide-toggle>
+            </div>
+        </mat-card-content>
+    </mat-card>
+
+</form>

--- a/frontend/src/app/components/settings/privacy-controls/privacy-controls.component.ts
+++ b/frontend/src/app/components/settings/privacy-controls/privacy-controls.component.ts
@@ -1,0 +1,21 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+
+@Component({
+  selector: 'app-privacy-controls',
+  templateUrl: './privacy-controls.component.html',
+  styles: [
+  ]
+})
+export class PrivacyControlsComponent implements OnInit {
+
+  // the privacy control cards are meant to be embedded in a page like the settings page or registration page
+  // the formGroup must have controls named 'privacyLevel', 'showAge', and 'showGender'
+  @Input() formGroup?: FormGroup;
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/frontend/src/app/components/settings/settings.component.html
+++ b/frontend/src/app/components/settings/settings.component.html
@@ -1,5 +1,5 @@
-<app-loading-bar *ngIf="isLoading"></app-loading-bar>
-<div *ngIf="!isLoading" style="padding-bottom: 10px;">
+<app-loading-bar *ngIf="info === undefined"></app-loading-bar>
+<div *ngIf="info !== undefined" style="padding-bottom: 10px;">
 	<mat-card style="margin-bottom: 30px;">
 		<mat-card-header>
 			<mat-card-title>User Info</mat-card-title>
@@ -53,12 +53,49 @@
 				<button (click)="refresh()" mat-icon-button><mat-icon>refresh</mat-icon></button>
 				<p style="margin-bottom: 0;">{{info!.emailAddress}}</p>
 			</div>
-			<p style="color: rgba(0,0,0,.54); text-align: center;">It might around one minute for Gravatar changes to be applied</p>
+			<p style="color: rgba(0,0,0,.54); text-align: center;">It might take around one minute for Gravatar changes to be applied</p>
 
 			<a href="//gravatar.com" target="_blank" style= "width: 100%;" color="primary" mat-raised-button>Upload an image on gravatar.com <mat-icon>launch</mat-icon></a>
 		</mat-card-content>
 
 	</mat-card>
+
+	<form [formGroup]="privacyForm" (submit)="updatePrivacySettings()">
+		<mat-card style="margin-bottom: 30px;">
+			<mat-card-header>
+				<mat-card-title>Profile Privacy</mat-card-title>
+				<mat-card-subtitle>Control who can see your profile</mat-card-subtitle>
+			</mat-card-header>
+			<mat-card-content style="padding-left: 16px;">
+				<mat-radio-group formControlName="privacyLevel" class="stacked-radio-group">
+					<mat-radio-button class="stacked-radio-button" color=primary value="public"> <mat-icon>public</mat-icon><span>Everyone</span></mat-radio-button>
+					<mat-radio-button class="stacked-radio-button" color=primary value="private"><mat-icon>group</mat-icon><span>Friends and Friends-of-Friends</span></mat-radio-button>
+					<mat-radio-button class="stacked-radio-button" color=primary value="restricted"><mat-icon>lock</mat-icon><span>Friends Only</span></mat-radio-button>
+				</mat-radio-group>
+				<div *ngIf="privacyForm.value.privacyLevel === 'restricted'"
+					style="display: flex; flex-direction: row; align-items: center; margin-top: 0.5em; margin-left: 5px; opacity: 50%;">
+
+					<mat-icon style="position: relative; bottom: 5px; margin-left: 5px;">warning</mat-icon>
+					<span>
+						You will not get Boop notifications about friends-of-friends when your profile is restricted.
+					</span>
+
+				</div>
+			</mat-card-content>
+		</mat-card>
+		<mat-card style="margin-bottom: 30px;">
+			<mat-card-header>
+				<mat-card-title>Profile Information</mat-card-title>
+				<mat-card-subtitle>Control what information is shown on your profile</mat-card-subtitle>
+			</mat-card-header>
+			<mat-card-content style="padding-left: 16px;">
+				<div style="display: flex; flex-direction: column;">
+					<mat-slide-toggle color="primary" formControlName="showGender">Show gender</mat-slide-toggle>
+					<mat-slide-toggle color="primary" formControlName="showAge">Show age</mat-slide-toggle>
+				</div>
+			</mat-card-content>
+		</mat-card>
+	</form>
 	<mat-card style="margin-bottom: 30px;">
 		<mat-card-header>
 			<mat-card-title>Change Password</mat-card-title>

--- a/frontend/src/app/components/settings/settings.component.html
+++ b/frontend/src/app/components/settings/settings.component.html
@@ -1,6 +1,6 @@
 <app-loading-bar *ngIf="info === undefined"></app-loading-bar>
 <div *ngIf="info !== undefined" style="padding-bottom: 10px;">
-	<mat-card style="margin-bottom: 30px;">
+	<mat-card>
 		<mat-card-header>
 			<mat-card-title>User Info</mat-card-title>
 		</mat-card-header>
@@ -42,7 +42,7 @@
 				[disabled]="!updateUserForm.valid || updateUserForm.pristine">Update</button>
 		</form>
 	</mat-card>
-	<mat-card style="margin-bottom: 30px;">
+	<mat-card>
 		<mat-card-header>
 			<mat-card-title>Profile Avatar</mat-card-title>
 			<mat-card-subtitle>Boop uses the Gravatar image linked to your email address</mat-card-subtitle>
@@ -63,7 +63,7 @@
 	<form [formGroup]="privacyForm" (submit)="updatePrivacySettings()">
 		<app-privacy-controls [formGroup]="privacyForm"></app-privacy-controls>
 	</form>
-	<mat-card style="margin-bottom: 30px;">
+	<mat-card>
 		<mat-card-header>
 			<mat-card-title>Change Password</mat-card-title>
 		</mat-card-header>
@@ -85,7 +85,7 @@
 				[disabled]="!changePasswordForm.valid">Update</button>
 		</form>
 	</mat-card>
-	<mat-card style="border: 2px solid #f44336">
+	<mat-card style="border: 2px solid #f44336; margin-bottom: 0;">
 		<mat-card-header>
 			<mat-card-title>Delete Account</mat-card-title>
 		</mat-card-header>

--- a/frontend/src/app/components/settings/settings.component.html
+++ b/frontend/src/app/components/settings/settings.component.html
@@ -61,40 +61,7 @@
 	</mat-card>
 
 	<form [formGroup]="privacyForm" (submit)="updatePrivacySettings()">
-		<mat-card style="margin-bottom: 30px;">
-			<mat-card-header>
-				<mat-card-title>Profile Privacy</mat-card-title>
-				<mat-card-subtitle>Control who can see your profile</mat-card-subtitle>
-			</mat-card-header>
-			<mat-card-content style="padding-left: 16px;">
-				<mat-radio-group formControlName="privacyLevel" class="stacked-radio-group">
-					<mat-radio-button class="stacked-radio-button" color=primary value="public"> <mat-icon>public</mat-icon><span>Everyone</span></mat-radio-button>
-					<mat-radio-button class="stacked-radio-button" color=primary value="private"><mat-icon>group</mat-icon><span>Friends and Friends-of-Friends</span></mat-radio-button>
-					<mat-radio-button class="stacked-radio-button" color=primary value="restricted"><mat-icon>lock</mat-icon><span>Friends Only</span></mat-radio-button>
-				</mat-radio-group>
-				<div *ngIf="privacyForm.value.privacyLevel === 'restricted'"
-					style="display: flex; flex-direction: row; align-items: center; margin-top: 0.5em; margin-left: 5px; opacity: 50%;">
-
-					<mat-icon style="position: relative; bottom: 5px; margin-left: 5px;">warning</mat-icon>
-					<span>
-						You will not get Boop notifications about friends-of-friends when your profile is restricted.
-					</span>
-
-				</div>
-			</mat-card-content>
-		</mat-card>
-		<mat-card style="margin-bottom: 30px;">
-			<mat-card-header>
-				<mat-card-title>Profile Information</mat-card-title>
-				<mat-card-subtitle>Control what information is shown on your profile</mat-card-subtitle>
-			</mat-card-header>
-			<mat-card-content style="padding-left: 16px;">
-				<div style="display: flex; flex-direction: column;">
-					<mat-slide-toggle color="primary" formControlName="showGender">Show gender</mat-slide-toggle>
-					<mat-slide-toggle color="primary" formControlName="showAge">Show age</mat-slide-toggle>
-				</div>
-			</mat-card-content>
-		</mat-card>
+		<app-privacy-controls [formGroup]="privacyForm"></app-privacy-controls>
 	</form>
 	<mat-card style="margin-bottom: 30px;">
 		<mat-card-header>

--- a/frontend/src/app/components/settings/settings.component.scss
+++ b/frontend/src/app/components/settings/settings.component.scss
@@ -2,9 +2,10 @@ mat-form-field {
 	width: 100%;
 }
 
-mat-card {
+:host ::ng-deep mat-card {
 	width: calc(100% - 60px);
 	margin: auto;
+	margin-bottom: 30px;
 }
 
 .update-button {

--- a/frontend/src/app/materialDependencies.ts
+++ b/frontend/src/app/materialDependencies.ts
@@ -13,6 +13,7 @@ import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { MatRadioModule } from '@angular/material/radio';
 
 // include all of the material component modules that we use here to avoid cluttering the main AppModule
 export const materialModules = [
@@ -30,6 +31,7 @@ export const materialModules = [
   MatProgressBarModule,
   MatTooltipModule,
   MatToolbarModule,
-  MatSlideToggleModule
+  MatSlideToggleModule,
+  MatRadioModule
 ];
 

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -31,3 +31,23 @@ body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
     max-height: 2em;
     margin-top: -0.5em;
 }
+
+.stacked-radio-group {
+    display: flex;
+    flex-direction: column;
+}
+
+.stacked-radio-button {
+    margin-bottom: 5px;
+
+    mat-icon {
+        position: relative;
+        top: 2px;
+        margin-right: 8px;
+    }
+
+    span {
+        position: relative;
+        bottom: 5px;
+    }
+}

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -13,6 +13,12 @@ body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
     }
 }
 
+// make the inside of outline mat-form-field be true white
+::ng-deep .mat-form-field-appearance-outline .mat-form-field-outline {
+    background-color: white;
+    border-radius: 5px;
+}
+
 .horizontal-center {
     display: flex;
     flex-direction: row;

--- a/init.sql
+++ b/init.sql
@@ -92,3 +92,98 @@ CREATE TABLE contact_methods(
     -- user's username/number/etc for that platform
     contact_id TEXT NOT NULL
 );
+
+
+-- function for selecting pairs of users to send notifications
+CREATE FUNCTION selectPairs(
+    timestamp_cutoff bigint,
+    friend_probability double precision,
+    metafriend_probability double precision
+) RETURNS TABLE (
+        user_a TEXT, user_b TEXT,
+        full_name_a TEXT, friendly_name_a TEXT, gender_a GENDER_IDENTITY, vapid_subs_a JSONB[],
+        full_name_b TEXT, friendly_name_b TEXT, gender_b GENDER_IDENTITY, vapid_subs_b JSONB[],
+        -- mutual friend fields are null for users who are friends
+        mutual_full_name TEXT, mutual_friendly_name TEXT, mutual_gender GENDER_IDENTITY
+) AS $$
+    -- find all the users that can be sent notifications right now
+    WITH enabled_users AS (
+        SELECT user_uuid
+        FROM users
+        WHERE (do_not_disturb IS NOT true) and (last_push_timestamp is null or last_push_timestamp < timestamp_cutoff)
+    ),
+    -- users with restricted profiles cannot match with friends-of-friends
+	    restricted_users AS (
+		    select user_uuid from users where profile_privacy_level = 'restricted'
+	    ),
+    -- find all the friend-of-friend relationships that don't include someone with a restricted profile
+    metafriends as (
+        select f1.user_a as user_a, f1.user_b as shared, f2.user_b as user_b
+        from friends f1 join friends f2 on f1.user_b = f2.user_a
+        where f1.user_a <> f2.user_b and f2.user_b not in (select f3.user_b from friends f3 where f3.user_a = f1.user_a)
+            and f1.user_a not in (select user_uuid from restricted_users)
+            and f2.user_b not in (select user_uuid from restricted_users)
+    ),
+    -- pick a random subset of users to get notifications about friends
+    friends_chosen_users AS (
+        SELECT user_uuid
+        FROM enabled_users
+        WHERE random() < friend_probability
+    ),
+    -- get the array of possible friends that those users could be paired with
+    friend_options AS (
+        SELECT user_a, array_agg(user_b order by random()) as user_bs
+        FROM friends_chosen_users join friends on friends_chosen_users.user_uuid = friends.user_a
+        group by user_a
+    ),
+    -- pick a random subset of users to get notifications about friends-of-friends
+    metafriends_chosen_users AS (
+        SELECT user_uuid
+        FROM enabled_users
+        WHERE random() < metafriend_probability
+    ),
+    -- get the array of possible friends-of-friends those users could be paired with
+    metafriend_options AS (
+        SELECT user_a, array_agg(ARRAY[user_b, shared] order by random()) as user_bs
+        FROM metafriends_chosen_users join metafriends on metafriends_chosen_users.user_uuid = metafriends.user_a
+        group by user_a
+    ),
+    friend_pairs as (
+        -- select one of the possible friends
+        select user_a, user_bs[1] as user_b, NULL::UUID as shared
+        from friend_options
+        -- note that the resulting set of pairs is likely to contain duplicates of the same user
+    ),
+    metafriend_pairs as (
+        select user_a, user_bs[1][1] as user_b, user_bs[1][2] as shared
+        from metafriend_options
+        -- note that the resulting set of pairs is likely to contain duplicates of the same user
+    ),
+    -- merge friend pairs and friend-of-friend pairs
+    all_pairs as (
+        select * from friend_pairs union all select * from metafriend_pairs
+    ),
+    -- collect user info for user a
+    a_info as (
+        select user_a, user_b, shared,
+        full_name as full_name_a, friendly_name as friendly_name_a, gender as gender_a, vapid_subs as vapid_subs_a
+        from all_pairs join users on user_a = user_uuid
+    ),
+    -- collect user info for user b
+    ab_info as (
+        select user_a, user_b, shared,
+        full_name_a, friendly_name_a, gender_a, vapid_subs_a,
+        full_name as full_name_b, friendly_name as friendly_name_b, gender as gender_b, vapid_subs as vapid_subs_b
+        from a_info join users on user_b = user_uuid
+    ),
+    -- collect user info for mutual friend if applicable
+    abc_info as (
+        select user_a, user_b,
+        full_name_a, friendly_name_a, gender_a, vapid_subs_a,
+        full_name_b, friendly_name_b, gender_b, vapid_subs_b,
+        full_name as mutual_full_name, friendly_name as mutual_friendly_name, gender as mutual_gender
+        from ab_info left join users on shared = user_uuid
+    )
+    -- return results in a random order
+    select * from abc_info order by random();
+$$ LANGUAGE SQL


### PR DESCRIPTION
adds ui support for changing three privacy settings:
- who can see the page (public, private, or restricted)
- whether to show gender on profile
- whether to show age on profile

ui to control these is included in the settings page and the registration page

![image](https://user-images.githubusercontent.com/40121408/109910470-2e515780-7c76-11eb-8545-5aa72239def2.png)

users with 'restricted' profiles (only visible to friends) will not be paired with friends-of-friends. I also made the pair selection query more efficient by moving it into a sql function, meaning that the node serve doesn't have to resend that entire query (more than 3 kilobytes!) every time

closes #61 