### PR TITLE
Organize backend configuration and keep VAPID private keys secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,31 @@ run the build and recompile core when you make changes.
 
 To build and run the server on localhost, run `npm run serve` from the backend directory.
 
+#### Setting Up VAPID keys
+
+Boop uses the web push protocol to send notifications, which requires a VAPID key pair. The server reads the keys
+from the `BOOP_VAPID_PUBLIC_KEY` and `BOOP_VAPID_PRIVATE_KEY` environment variables, which can also be configured
+by creating a file at `backend/.env` that looks like this:
+
+```
+BOOP_VAPID_PUBLIC_KEY=Public_Key_Goes_Here
+BOOP_VAPID_PRIVATE_KEY=Private_Key_Goes_Here
+```
+
+You can generate a new key pair for your instance of the Boop server by navigating to the backend directory and running
+`npx web-push generate-vapid-keys`.
+
 #### Backend environment variables
-- `PORT` port for express server. Defaults to 3000.
+- `BOOP_VAPID_PUBLIC_KEY` public half of a VAPID key pair for web push notifications
+- `BOOP_VAPID_PRIVATE_KEY` private half of a VAPID key pair for web push notifications
+- `PORT` port for Express server. Defaults to 3000.
 - `PGUSER` username to use to connect to postgres. Defaults to 'postgres'.
 - `PGPASSWORD` password to use to connect to postgres.
 - `PGHOST` host url of Postgres server. Defaults to 'localhost'.
 
 #### Backend server command line options:
-- `--pg-password <your postgres password>` password to use to connect to postgres. Overrides "PGPASSWORD" environment variable.
+- `--pg-password <your postgres password>` password to use to connect to postgres. Overrides "PGPASSWORD" environment
+    variable.
 - `--pg-user <your postgres username>` username to use to connect to postgres. Overrides "PGUSER" environment variable.
 - `--frequent-push` speeds up the frequency of push notifications to several per minute instead of once every few hours,
     for testing the push notification system

--- a/README.md
+++ b/README.md
@@ -37,13 +37,17 @@ run the build and recompile core when you make changes.
 
 To build and run the server on localhost, run `npm run serve` from the backend directory.
 
-#### Backend server command line options:
-- `--password <your postgres password>` password to use to connect to postgres. If this argument is not provided, the
-backend will instead check for an environment variable named `postgres_password`.
-- `--sqlUser <your postgres username>` username to use to connect to postgres. Defaults to 'postgres'.
-- `--frequentPush` speeds up the frequency of push notifications to several per minute instead of once every few hours,
-    for testing the push notification system
+#### Backend environment variables
+- `PORT` port for express server. Defaults to 3000.
+- `PGUSER` username to use to connect to postgres. Defaults to 'postgres'.
+- `PGPASSWORD` password to use to connect to postgres.
+- `PGHOST` host url of Postgres server. Defaults to 'localhost'.
 
+#### Backend server command line options:
+- `--pg-password <your postgres password>` password to use to connect to postgres. Overrides "PGPASSWORD" environment variable.
+- `--pg-user <your postgres username>` username to use to connect to postgres. Overrides "PGUSER" environment variable.
+- `--frequent-push` speeds up the frequency of push notifications to several per minute instead of once every few hours,
+    for testing the push notification system
 
 
 ### Running the Angular frontend locally

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -2436,6 +2436,11 @@
         "is-obj": "^2.0.0"
       }
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,6 +20,7 @@
     "body-parser": "^1.19.0",
     "boop-core": "file:../core",
     "cors": "^2.8.5",
+    "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "gravatar": "^1.8.1",
     "luxon": "^1.26.0",

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -1,0 +1,26 @@
+import parseArgs from "minimist";
+
+// application configuration info using command line arguments and environment variables
+// when both a command line argument and an environment variable can be used, the argument has higher precedence
+
+// command line arguments passed to node
+const args = parseArgs(process.argv.slice(2));
+// environment variables
+const env = process.env;
+
+export const config = {
+  // port used for Express server
+  expressPort: env["PORT"] ?? 3000,
+  // postgres database credentials
+  databaseConnectionSettings: {
+    user: args["pg-user"] ?? env["PGUSER"] ?? "postgres",
+    // there are two different environment variable names for the database password
+    // 'postgres_password' is included to remain compatible with setup instructions previously given to team members
+    password: args["pg-password"] ?? env["PGPASSWORD"] ?? env["postgres_password"],
+    host: env["PGHOST"] ?? "localhost",
+    database: env["PGDATABASE"] ?? "boop",
+    port: 5432,
+  },
+  // causes users to get boop notifications every few seconds instead of every few hours (for notification testing)
+  highFrequencyNotifications: !!args["frequent-push"]
+};

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -1,4 +1,7 @@
 import parseArgs from "minimist";
+import dotenv from "dotenv";
+
+dotenv.config(); // if a .env file is present, dotenv configures process.env with values from that file
 
 // application configuration info using command line arguments and environment variables
 // when both a command line argument and an environment variable can be used, the argument has higher precedence
@@ -8,19 +11,48 @@ const args = parseArgs(process.argv.slice(2));
 // environment variables
 const env = process.env;
 
-export const config = {
+// show a message and halt startup if vapid keys are not provided
+function missingKeyWarning(): never {
+  console.error(
+    "Fatal Error: VAPID key pair not found!"
+    + "\nMake sure that the environment variables BOOP_VAPID_PUBLIC_KEY and BOOP_VAPID_PRIVATE_KEY are both set."
+  );
+  process.exit();
+}
+
+type BoopConfiguration = {
   // port used for Express server
-  expressPort: env["PORT"] ?? 3000,
+  expressPort: string | number;
   // postgres database credentials
   databaseConnectionSettings: {
+    user: string;
+    password: string;
+    host: string;
+    database: string;
+    port: number;
+  };
+  // authentication keys for web-push protocol
+  vapidKeys: {
+    publicKey: string;
+    privateKey: string;
+  };
+  // notification testing mode: causes users to get boop notifications every few seconds instead of every few hours
+  highFrequencyNotifications: boolean;
+};
+
+export const config: BoopConfiguration = {
+  expressPort: env["PORT"] ?? 3000,
+  databaseConnectionSettings: {
     user: args["pg-user"] ?? env["PGUSER"] ?? "postgres",
-    // there are two different environment variable names for the database password
     // 'postgres_password' is included to remain compatible with setup instructions previously given to team members
     password: args["pg-password"] ?? env["PGPASSWORD"] ?? env["postgres_password"],
     host: env["PGHOST"] ?? "localhost",
     database: env["PGDATABASE"] ?? "boop",
     port: 5432,
   },
-  // causes users to get boop notifications every few seconds instead of every few hours (for notification testing)
+  vapidKeys: {
+    publicKey: env["BOOP_VAPID_PUBLIC_KEY"] ?? missingKeyWarning(),
+    privateKey: env["BOOP_VAPID_PRIVATE_KEY"] ?? missingKeyWarning(),
+  },
   highFrequencyNotifications: !!args["frequent-push"]
 };

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -11,12 +11,15 @@ import { userInfoRouter } from "./routers/userInfoRouter";
 import { friendsRouter } from "./routers/friendsRouter";
 import { contactRouter } from "./routers/contactRouter";
 import { profileRouter } from "./routers/profileRouter";
+import { config } from "./config";
 
 const app = express();
-const port = process.env.PORT ?? 3000;
+const port = config.expressPort;
 
 // middleware
 app.use((req, res, next) => { next(); }, cors());
+// intellisense might warn that bodyParser is deprecated, even though the way we are using it is not deprecated
+// this is a bug causes by Express having a deprecated function with the same name as a non-deprecated namespace.
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(bodyParser.json());
 app.use(bodyParser.text());

--- a/backend/src/routers/pushSubscriptionRouter.ts
+++ b/backend/src/routers/pushSubscriptionRouter.ts
@@ -1,4 +1,5 @@
 import express from "express";
+import { config } from "../config";
 import { addPushSubscription } from "../queries/pushQueries";
 import { authenticateUUID, } from "../services/auth";
 import { isWebpushSubscription } from "../services/pushManager";
@@ -16,4 +17,9 @@ subscriptionRouter.post('/addSubscription', handleAsync(async (req, res) => {
   const userUUID = await authenticateUUID(req);
   await addPushSubscription(req.body, userUUID);
   res.send();
+}));
+
+subscriptionRouter.get('/vapid_public_key', handleAsync(async (req, res) => {
+  res.send(config.vapidKeys.publicKey);
+  console.log(res.getHeaders());
 }));

--- a/backend/src/services/database.ts
+++ b/backend/src/services/database.ts
@@ -1,5 +1,5 @@
 import pg, { Pool } from "pg";
-import parseArgs from "minimist";
+import { config } from "../config";
 
 // manages our connection to PostgreSQL database
 class Database {
@@ -7,20 +7,7 @@ class Database {
   private pool: pg.Pool; // a pool of connection clients allows us to make concurrent queries
 
   constructor() {
-    /* To connect to the database, we need to have the computer's postgres superuser password
-    * The first place we look is the --password command-line argument. If that argument is not included,
-    * we next look for an environment variable called "postgres_password".
-    */
-    const passwordArgument: string | undefined = parseArgs(process.argv.slice(2))["password"];
-    const usernameArgument: string | undefined = parseArgs(process.argv.slice(2))["sqlUser"] ?? 'postgres';
-
-    this.pool = new Pool({
-      user: process.env.PGUSER ?? usernameArgument,
-      host: process.env.PGHOST ?? 'localhost',
-      database: process.env.PGDATABASE ?? 'boop',
-      password: process.env.PGPASSWORD ?? process.env.postgres_password ?? passwordArgument,
-      port: 5432,
-    });
+    this.pool = new Pool(config.databaseConnectionSettings);
   }
 
   // performs a single query

--- a/backend/src/services/periodicJobs.ts
+++ b/backend/src/services/periodicJobs.ts
@@ -23,10 +23,6 @@ function clearExpiredPushTokens(): void {
 }
 
 export function startRepeatedJobs(): void {
-  // start cleanup tasks once at startup
-  clearExpiredSessions();
-  clearExpiredPushTokens();
-
   // check for expired user sessions every hour
   setInterval(clearExpiredSessions, (60 * 60 * 1000));
   // check for expired push tokens every 12 hours
@@ -38,4 +34,11 @@ export function startRepeatedJobs(): void {
       console.error(err);
     });
   }, scheduleParameters.interval);
+
+  // schedule cleanup tasks to run once shortly after startup in addition to the regular schedule
+  // we wait so that this does not return before the database connection check completes
+  setTimeout(() => {
+    clearExpiredSessions();
+    clearExpiredPushTokens();
+  }, 10000);
 }

--- a/backend/src/services/pushManager.ts
+++ b/backend/src/services/pushManager.ts
@@ -1,10 +1,10 @@
-import { vapidKeys } from "boop-core";
 import webpush from "web-push";
+import { config } from "../config";
 
 webpush.setVapidDetails(
-  'mailto:gracerarer@gatech.edu', // TODO create an email address for boop
-  vapidKeys.publicKey,
-  vapidKeys.privateKey
+  'mailto:boopsocialapp@gmail.com',
+  config.vapidKeys.publicKey,
+  config.vapidKeys.privateKey
 );
 
 // send a notification to all vapid endpoints associated with the given user

--- a/backend/src/services/reminders/scheduleTuning.ts
+++ b/backend/src/services/reminders/scheduleTuning.ts
@@ -1,5 +1,5 @@
 
-import parseArgs from "minimist";
+import { config } from "../../config";
 
 // average person is selected around once per day, so gets on average between one and two pushes per day
 const standardScheduleParameters = {
@@ -15,15 +15,15 @@ const standardScheduleParameters = {
 
 // substitute parameters that cause pushes to happen very frequently for testing purposes
 const testScheduleParameters = {
+  // 10 seconds
   cooldown: 10000,
+  // 5 seconds
   interval: 5000,
   friendProbability: 0.5,
   metafriendProbability: 0.5,
 };
 
 export const scheduleParameters: typeof standardScheduleParameters =
-  parseArgs(process.argv.slice(2))["frequentPush"]
-    ? testScheduleParameters
-    : standardScheduleParameters;
+  config.highFrequencyNotifications ? testScheduleParameters : standardScheduleParameters;
 
 

--- a/core/src/api.ts
+++ b/core/src/api.ts
@@ -1,9 +1,1 @@
 export const sessionTokenHeaderName = "boop-token";
-
-// TODO keep private key secret
-// for now the prototype has the vapid keys directly in source code, but we should eventually store it securely
-// and then generate a new pair of keys that are not checked into version control
-export const vapidKeys = {
-  "publicKey": "BHFciY9_wuokC43Tkd7g4bPYctnTFlqc1rHzKgShdTxE2_AJFAvSJz1q3QXf4OQKDp0CcrDM4CK8mIPfG17iv78",
-  "privateKey": "HDlJaMhdqp3W8NjwLy34Gi_163wWRPCeZAwYk5Z-ml4"
-};

--- a/frontend/src/app/components/push-subscribe/push-subscribe.component.ts
+++ b/frontend/src/app/components/push-subscribe/push-subscribe.component.ts
@@ -2,7 +2,6 @@ import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
 import { SwPush } from '@angular/service-worker';
-import { vapidKeys } from 'boop-core';
 import { ApiService } from 'src/app/services/api.service';
 
 @Component({
@@ -50,9 +49,8 @@ export class PushSubscribeComponent implements OnInit {
   }
 
   private async subscribe(): Promise<void> {
-    const subscription = await this.swPush.requestSubscription({
-      serverPublicKey: vapidKeys.publicKey
-    });
+    const publicKey = await this.apiService.getText("http://localhost:3000/push/vapid_public_key");
+    const subscription = await this.swPush.requestSubscription({ serverPublicKey: publicKey });
     await this.apiService.postJSON<PushSubscriptionJSON, void>(
       "http://localhost:3000/push/addSubscription", subscription.toJSON()
     );

--- a/frontend/src/app/services/api.service.ts
+++ b/frontend/src/app/services/api.service.ts
@@ -28,6 +28,19 @@ export class ApiService {
     return this.httpClient.get<ResponseBodyT>(endPointUrl, options).toPromise();
   }
 
+  // like getJSON, but interprets response body as a raw string instead of parsing it as json
+  async getText(
+    endPointUrl: string,
+    queryParams?: {[param: string]: string | string[];}
+  ): Promise<string> {
+    const options = {
+      params: queryParams,
+      headers: this.getAuthenticationHeader(),
+      responseType: 'text' as const
+    };
+    return this.httpClient.get(endPointUrl, options).toPromise();
+  }
+
   async postJSON<RequestBodyT, ResponseBodyT>(
     endPointUrl: string,
     body: RequestBodyT

--- a/init.sql
+++ b/init.sql
@@ -50,10 +50,13 @@ CREATE TABLE administrators(
 
 -- create special admin account
 INSERT INTO users
-("user_uuid", "username", "bcrypt_hash", "full_name", "friendly_name", "gender", "email", "birth_date")
-VALUES ('689b90d7-41ed-4257-a2a1-ca6d608d28f7', 'admin', '$2b$09$6Xjk49GbCZTjoognkzPk2.pyblewRbaiHLGap0PjETNNX924or4xS',
-'Boop Administrator', 'Administrator', null, 'example@example.com', '2000-01-15');
-INSERT INTO administrators(admin_user_uuid) values ('689b90d7-41ed-4257-a2a1-ca6d608d28f7');
+("user_uuid", "username", "bcrypt_hash",
+"full_name", "friendly_name", "email", "birth_date", "profile_privacy_level",
+"profile_show_age", "profile_show_gender")
+VALUES ('00000000-0000-0000-0000-000000000000', 'admin', '$2b$09$6Xjk49GbCZTjoognkzPk2.pyblewRbaiHLGap0PjETNNX924or4xS',
+'Boop Administrator', 'Administrator', 'boopsocialapp@gmail.com', '2000-01-01', 'restricted',
+'false', 'false');
+INSERT INTO administrators(admin_user_uuid) values ('00000000-0000-0000-0000-000000000000');
 
 -- user log-in sessions
 CREATE TABLE sessions(


### PR DESCRIPTION
All command-line and environment-variable configuration settings for the backend are now organized in one place. The command line arguments have been changed to snake-case to match convention.

VAPID keys are now stored as backend environment variables rather than being part of the source code, which means we can generate a new keypair and keep the new private key secret. The readme has been updated with instructions for generating a new keypair. This resolves #63.

The dotenv package has been added to the backend to make it easier to configure environment variables: you can create a `backend/.env` file rather than having to change your computer's actual environment variables.