### PR TITLE
set up continuous integration for front-end

### DIFF
--- a/.github/workflows/deploy_site.yaml
+++ b/.github/workflows/deploy_site.yaml
@@ -1,0 +1,33 @@
+# build frontend and deploy to github pages
+name: Deploy Web-App
+
+on:
+  push:
+    branches: [ $default-branch ]
+
+jobs:
+  build-and-deploy-angular:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    # build core package
+    - uses: bahmutov/npm-install@v1.6.2
+      with:
+        working-directory: ./core
+    - name: build-core
+      run: npm run build
+      working-directory: ./core
+    # build frontend package
+    - uses: bahmutov/npm-install@v1.6.2
+      with:
+        working-directory: ./frontend
+    - name: build-frontend
+      run: npm run build-prod
+      working-directory: ./frontend
+    # deploy build output to github pages
+    - name: deploy
+      uses: JamesIves/github-pages-deploy-action@4.1.0
+      with:
+        branch: gh-pages # The branch the action should deploy to.
+        folder: ./frontend/dist/boop-web # The folder the action should deploy.

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -82,8 +82,8 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500kb",
-                  "maximumError": "1mb"
+                  "maximumWarning": "2mb",
+                  "maximumError": "4mb"
                 },
                 {
                   "type": "anyComponentStyle",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "build": "ng build",
     "build-pwa": "npx ng build --service-worker",
     "start-pwa": "npm run build-pwa && npx http-server ./dist/boop-web",
+    "build-prod": "npx ng build --service-worker --prod",
     "lint": "npx eslint src --ext .ts"
   },
   "eslintIgnore": [


### PR DESCRIPTION
This PR adds a GitHub Actions script to build and deploy the production front-end to GitHub pages whenever the main branch is updated.

Note we haven't configured the production mode to use the production server on AWS yet, so the deployed app won't actually be functional at this stage.