### PR TITLE
fix opacity of profile text in prod modified

### DIFF
--- a/frontend/src/app/components/profile/profile.component.html
+++ b/frontend/src/app/components/profile/profile.component.html
@@ -13,8 +13,8 @@
         </div>
         <!-- display different controls depending on requester's relationship to profile -->
         <button *ngIf="relation!.self" mat-raised-button color="primary" class="action-link" routerLink="/edit_profile"><mat-icon>edit</mat-icon> Edit Profile</button>
-        <p *ngIf="relation!.friend"  class="friend-label"><mat-icon>group</mat-icon>You are friends with this user.</p>
-        <p *ngIf="relation!.pendingFriendRequest === 'outgoing'" class="friend-label"><mat-icon>people_outline</mat-icon>You send a friend request to this user.</p>
+        <p *ngIf="relation!.friend"  class="friend-label" style="opacity: 80%;"><mat-icon style="opacity: 60%;">group</mat-icon>You are friends with this user.</p>
+        <p *ngIf="relation!.pendingFriendRequest === 'outgoing'" class="friend-label" style="opacity: 80%;"><mat-icon style="opacity: 60%;">people_outline</mat-icon>You sent a friend request to this user.</p>
         <button *ngIf="relation!.pendingFriendRequest === 'incoming'" mat-raised-button class="action-link" routerLink="/add_friends"><mat-icon>person_add_alt_1</mat-icon> This User Sent You A Friend Request</button>
         <button *ngIf="relation!.viewerLoggedIn && !relation!.self && !relation!.friend && !relation!.pendingFriendRequest" mat-raised-button class="action-link" (click)="sendFriendRequest()"><mat-icon>person_add_alt_1</mat-icon> Send Friend Request</button>
 

--- a/frontend/src/app/components/profile/profile.component.scss
+++ b/frontend/src/app/components/profile/profile.component.scss
@@ -81,12 +81,10 @@
 .friend-label {
     margin-top: -10px;
     font-size: medium;
-    opacity: 80%;
     text-align: center;
     mat-icon {
         position: relative;
         top: 5px;
         margin-right: 5px;
-        opacity: 60%;
     }
 }


### PR DESCRIPTION
there is a bug in how Angular's production compilation mode minifies
scss, which caused the 80% opacity of the "you are friends with this
user" text to be set to 1% instead. moving the opacity settings out
of scss and into inline styles in html fixes this problem.

resolves #81 