### PR TITLE
fix incorrect cooldown time

### DIFF
--- a/backend/src/services/reminders/scheduleTuning.ts
+++ b/backend/src/services/reminders/scheduleTuning.ts
@@ -4,9 +4,9 @@ import { config } from "../../config";
 // average person is selected around once per day, so gets on average between one and two pushes per day
 const standardScheduleParameters = {
   // 4 hours, minimum time between pushes to the same user
-  cooldown: 28800000,
+  cooldown: 4 * 60 * 60 * 1000,
   // 10 minutes, time between iterations of scheduling (milliseconds)
-  interval: 600000,
+  interval: 10 * 60 * 1000,
   // probability of an eligible user being selected for a friend notification in one iteration
   friendProbability: 0.166,
   // probability of an eligible user being selected for a friend-of-friend notification in one iteration


### PR DESCRIPTION
notification cooldown time was intended to be 4 hours, but had actually been set to 80 hours