### PR TITLE
automatically remove dead push subscriptions

### DIFF
--- a/backend/src/queries/pushQueries.ts
+++ b/backend/src/queries/pushQueries.ts
@@ -11,14 +11,12 @@ export async function addPushSubscription(subscription: webpush.PushSubscription
     [subscriptionString, userUUID]);
 }
 
-export async function getPushByUsername(username: string): Promise<webpush.PushSubscription[]> {
-  const query = `select vapid_subs from users where username = $1`;
-  type Row = {vapid_subs: webpush.PushSubscription[];};
-  const result = (await database.query<Row>(query, [username]));
-  if (result.length === 0) {
-    throwBoopError("user not found", 404);
-  }
-  return result[0].vapid_subs;
+export async function removePushSubscription(subscription: webpush.PushSubscription, userUUID: string): Promise<void> {
+  const subscriptionString = JSON.stringify(subscription);
+  await database.query(
+    `UPDATE USERS SET vapid_subs = array_remove(vapid_subs, $1) where user_uuid = $2;`,
+    [subscriptionString, userUUID]
+  );
 }
 
 export async function getPushByUUID(userUUID: string): Promise<webpush.PushSubscription[]> {

--- a/backend/src/routers/friendsRouter.ts
+++ b/backend/src/routers/friendsRouter.ts
@@ -41,7 +41,7 @@ async function createFriendRequest(fromUUID: string, toUUID: string): Promise<vo
   );
   // send notification to recipient of friend request
   const subs = await getPushByUUID(toUUID);
-  sendNotificationToUser(subs, await friendRequestNotification(fromUUID))
+  sendNotificationToUser(subs, await friendRequestNotification(fromUUID), toUUID)
     .catch(err => { console.error(err); });
 }
 
@@ -96,7 +96,7 @@ friendsRouter.post('/answer_request', handleAsync(async (req, res) => {
 
     // Send notification to the sender of the request
     const subs = await getPushByUUID(body.friendUUID);
-    sendNotificationToUser(subs, await friendAcceptNotification(userUUID))
+    sendNotificationToUser(subs, await friendAcceptNotification(userUUID), body.friendUUID)
       .catch(err => { console.error(err); });
   } else {
     // just remove friend request

--- a/backend/src/services/reminders/reminders.ts
+++ b/backend/src/services/reminders/reminders.ts
@@ -48,8 +48,8 @@ export async function sendReminders(pair: Pairing): Promise<void> {
   const tokens = await createNotificationTokens(pair);
 
   await Promise.all([
-    sendNotificationToUser(pair.userA.vapidSubs, boopNotificationPayload(messageToA, tokens.tokenToA)),
-    sendNotificationToUser(pair.userB.vapidSubs, boopNotificationPayload(messageToB, tokens.tokenToB))
+    sendNotificationToUser(pair.userA.vapidSubs, boopNotificationPayload(messageToA, tokens.tokenToA), pair.userA.uuid),
+    sendNotificationToUser(pair.userB.vapidSubs, boopNotificationPayload(messageToB, tokens.tokenToB), pair.userB.uuid)
   ]);
 }
 


### PR DESCRIPTION
adds automatic removal of web push subscriptions that result in a "410 gone" response, which VAPID servers use to indicate that the subscription's permission has been deactivated. resolves #103 