### PR TITLE
fix issues with webpush compatibility

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -34,6 +34,9 @@ import {
   EditableContactCardsComponent
 } from './components/edit-contact-info/editable-contact-cards/editable-contact-cards.component';
 import { FaqDialogComponent } from './components/common/faq-dialog/faq-dialog.component';
+import {
+  IncompatibilityDialogComponent
+} from './components/common/incompatibility-dialog/incompatibility-dialog.component';
 
 /* eslint-disable @typescript-eslint/no-extraneous-class */
 @NgModule({
@@ -58,6 +61,7 @@ import { FaqDialogComponent } from './components/common/faq-dialog/faq-dialog.co
     RegistrationComponent,
     EditableContactCardsComponent,
     FaqDialogComponent,
+    IncompatibilityDialogComponent,
   ],
   imports: [
     BrowserModule,

--- a/frontend/src/app/components/common/incompatibility-dialog/incompatibility-dialog.component.html
+++ b/frontend/src/app/components/common/incompatibility-dialog/incompatibility-dialog.component.html
@@ -1,0 +1,19 @@
+<h1 mat-dialog-title>Your web browser does not support web push notifications</h1>
+<div mat-dialog-content>
+    <p>Boop uses push notifications to remind you to talk with your friends. Unfortunately, it seems that
+        your current web browser or device does not support web-push notifications. You can still use this browser
+        to create an account, edit your profile profile, and connect with your friends, but to make use of Boop
+        notifications you will need to sign in with a different web browser. </p>
+    <p>Web push notifications are supported on Chrome, Firefox, and Edge browsers for Android, Windows, Linux,
+        and MacOS.
+    </p>
+    <p>Unfortunately, Apple does not currently allow web-push notifications on iOS devices and some versions of Safari
+        for Mac. If you exclusively use Apple devices, we encourage you to use Boop via <a
+            href="//google.com/chrome">Google Chrome</a>
+        or <a href="https://www.mozilla.org/en-US/firefox/new/">Firefox</a> on your Mac.
+    </p>
+</div>
+<div mat-dialog-actions>
+    <button mat-button mat-dialog-close>Close</button>
+    <button mat-button mat-dialog-close (click)="dontShowAgain()">Don't Show Again</button>
+</div>

--- a/frontend/src/app/components/common/incompatibility-dialog/incompatibility-dialog.component.ts
+++ b/frontend/src/app/components/common/incompatibility-dialog/incompatibility-dialog.component.ts
@@ -1,0 +1,21 @@
+import { Component, OnInit } from '@angular/core';
+
+export const skipIncompatibilityLSKey = "boop-skip-incompatibility-dialog";
+
+@Component({
+  selector: 'app-incompatibility-dialog',
+  templateUrl: './incompatibility-dialog.component.html',
+  styles: ['h2 {margin-bottom: 0}']
+})
+export class IncompatibilityDialogComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+  dontShowAgain(): void {
+    window.localStorage.setItem(skipIncompatibilityLSKey, "skip");
+  }
+
+}

--- a/frontend/src/app/services/subscription.service.ts
+++ b/frontend/src/app/services/subscription.service.ts
@@ -1,0 +1,80 @@
+import { Injectable } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { SwPush } from '@angular/service-worker';
+import { ApiService } from './api.service';
+
+// service for subscribing to web push notifications
+@Injectable({
+  providedIn: 'root'
+})
+export class SubscriptionService {
+
+  constructor(
+    private apiService: ApiService,
+    private swPush: SwPush,
+    private snackBar: MatSnackBar
+  ) { }
+
+  // cached between uses so that we only have to query for this once
+  private vapidPublicKey?: string;
+
+  private async getVapidPublicKey(): Promise<string> {
+    if (this.vapidPublicKey !== undefined) {
+      return this.vapidPublicKey;
+    } else {
+      const key = await this.apiService.getText("push/vapid_public_key");
+      this.vapidPublicKey = key;
+      return key;
+    }
+  }
+
+  // requests and stores the public key so that it will be available immediately the next time it is needed
+  preFetchVapidPublicKey(): void {
+    // lookup public key, discarding the result and ignoring errors
+    void this.getVapidPublicKey();
+  }
+
+  webPushSupported(): boolean {
+    // check if angular thinks notifications are enabled
+    if (!this.swPush.isEnabled) {
+      return false;
+    }
+    // verify that the PushSubscription class is part of the global browser namespace
+    try {
+      console.log("trying compatibility check");
+      // on nonsupporting browsers, this causes an error because the PushSubscription class is undefined
+      const neverTrue: boolean = {} instanceof PushSubscription;
+      console.log("instance check passed");
+      if (neverTrue) {
+        // this should never happen
+        console.error("empty object found to be an instance of PushSubscription class");
+        return false;
+      }
+    } catch (err) {
+      console.warn("PushSubscription API appears unsupported", err);
+      return false;
+    }
+    return true;
+  }
+
+  showNotEnabledMessage(): void {
+    this.snackBar.open("Your platform or browser does not support Web Push Notifications.", "Dismiss");
+  }
+
+  async createSubscription(): Promise<PushSubscriptionJSON> {
+    if (!this.webPushSupported()) {
+      throw "Your platform or browser does not support Web Push Notifications.";
+    }
+    const publicKey = await this.getVapidPublicKey();
+    try {
+      const subscription = await this.swPush.requestSubscription({ serverPublicKey: publicKey });
+      return subscription.toJSON();
+    } catch (reason) {
+      if (reason instanceof DOMException && reason.name === "NotAllowedError") {
+        throw "You (or your web browser) blocked permission for push notifications.";
+      } else {
+        throw reason;
+      }
+    }
+  }
+}


### PR DESCRIPTION
refactors web-push subscription and improves detection of platforms that don't support the web-push API's that we use (e.g. sanjana's macbook)

users who use those platforms will also now get a dialog explaining that they should instead use a supported browser and OS

also improves responsiveness of web-push subscriptions by pre-fetching the public key when the user opens the registration or notification subscription page