### PR TITLE
add label explaining the purpose of contact info

### DIFF
--- a/frontend/src/app/components/edit-contact-info/editable-contact-cards/editable-contact-cards.component.html
+++ b/frontend/src/app/components/edit-contact-info/editable-contact-cards/editable-contact-cards.component.html
@@ -1,5 +1,6 @@
 <div style="display: flex; flex-direction: column; height: 100%;">
     <h2 style="text-align: center; margin-bottom: 0;">Which chat apps do you use?</h2>
+    <p style="text-align: center; width: calc(100% - 60px); margin: auto; margin-bottom: 5px;">Let your friends know how to start a conversation with you</p>
     <div style="flex-grow: 1;  overflow: auto;">
         <div style="height: 100%;">
             <mat-card *ngFor="let contact of contacts!; index as index;">


### PR DESCRIPTION
Juan's UX research showed that users didn't necessarily understand why we are asking for their social messaging contact info.

![image](https://user-images.githubusercontent.com/40121408/113031383-a3705980-915c-11eb-8acc-895255e10bca.png)
